### PR TITLE
small change for akka actor supervise strategy and UT for akka actor functionality

### DIFF
--- a/client/src/main/java/com/flipkart/flux/client/intercept/TaskInterceptor.java
+++ b/client/src/main/java/com/flipkart/flux/client/intercept/TaskInterceptor.java
@@ -16,7 +16,7 @@ package com.flipkart.flux.client.intercept;
 
 import com.flipkart.flux.api.EventDefinition;
 import com.flipkart.flux.client.model.Task;
-import com.flipkart.flux.client.registry.Executable;
+import com.flipkart.flux.client.registry.ExecutableImpl;
 import com.flipkart.flux.client.registry.ExecutableRegistry;
 import com.flipkart.flux.client.runtime.LocalContext;
 import org.aopalliance.intercept.MethodInterceptor;
@@ -55,7 +55,7 @@ public class TaskInterceptor implements MethodInterceptor {
         final Task taskAnnotation = method.getAnnotationsByType(Task.class)[0];
         final String taskIdentifier = generateTaskIdentifier(method);
         localContext.registerNewState(taskAnnotation.version(), generateStateIdentifier(method) ,null,null, taskIdentifier,taskAnnotation.retries(),taskAnnotation.timeout(),generateEventDefs(method));
-        executableRegistry.registerTask(taskIdentifier,new Executable(invocation.getThis(),invocation.getMethod(), taskAnnotation.timeout()));
+        executableRegistry.registerTask(taskIdentifier,new ExecutableImpl(invocation.getThis(),invocation.getMethod(), taskAnnotation.timeout()));
         return null;
     }
 

--- a/client/src/main/java/com/flipkart/flux/client/registry/Executable.java
+++ b/client/src/main/java/com/flipkart/flux/client/registry/Executable.java
@@ -1,62 +1,8 @@
 package com.flipkart.flux.client.registry;
 
-import com.flipkart.flux.client.intercept.MethodId;
+public interface Executable {
 
-import java.lang.reflect.Method;
-
-/**
- * This provides a way for the core runtime to execute client side code
- * @author yogesh.nachnani
- */
-public class Executable {
-
-    private final Method toInvoke;
-    private final Object singletonMethodOwner;
-    private final long timeout;
-
-    public Executable(Object singletonMethodOwner, Method toInvoke, long timeout) {
-        this.singletonMethodOwner = singletonMethodOwner;
-        this.toInvoke = toInvoke;
-        this.timeout = timeout;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        Executable that = (Executable) o;
-
-        if (timeout != that.timeout) return false;
-        if (!toInvoke.equals(that.toInvoke)) return false;
-        return singletonMethodOwner.equals(that.singletonMethodOwner);
-
-    }
-
-    @Override
-    public int hashCode() {
-        int result = toInvoke.hashCode();
-        result = 31 * result + singletonMethodOwner.hashCode();
-        result = 31 * result + (int) (timeout ^ (timeout >>> 32));
-        return result;
-    }
-
-    @Override
-    public String toString() {
-        return "Executable{" +
-            "singletonMethodOwner=" + singletonMethodOwner +
-            ", toInvoke=" + toInvoke +
-            '}';
-    }
-    public String getName() {
-        return new MethodId(toInvoke).getMethodName();
-    }
-
-    public Object execute(Object[] parameters) {
-        throw new UnsupportedOperationException("not implemented yet");
-    }
-
-    public long getTimeout() {
-        return timeout;
-    }
+    String getName();
+    long getTimeout();
+    Object execute(Object[] parameters);
 }

--- a/client/src/main/java/com/flipkart/flux/client/registry/ExecutableImpl.java
+++ b/client/src/main/java/com/flipkart/flux/client/registry/ExecutableImpl.java
@@ -1,0 +1,63 @@
+package com.flipkart.flux.client.registry;
+
+import com.flipkart.flux.client.intercept.MethodId;
+
+import java.lang.reflect.Method;
+
+/**
+ * This provides a way for the core runtime to execute client side code
+ * @author yogesh.nachnani
+ */
+public class ExecutableImpl implements Executable {
+
+    private final Method toInvoke;
+    private final Object singletonMethodOwner;
+    private final long timeout;
+
+    public ExecutableImpl(Object singletonMethodOwner, Method toInvoke, long timeout) {
+        this.singletonMethodOwner = singletonMethodOwner;
+        this.toInvoke = toInvoke;
+        this.timeout = timeout;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ExecutableImpl that = (ExecutableImpl) o;
+
+        if (timeout != that.timeout) return false;
+        if (!toInvoke.equals(that.toInvoke)) return false;
+        return singletonMethodOwner.equals(that.singletonMethodOwner);
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = toInvoke.hashCode();
+        result = 31 * result + singletonMethodOwner.hashCode();
+        result = 31 * result + (int) (timeout ^ (timeout >>> 32));
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "Executable{" +
+            "singletonMethodOwner=" + singletonMethodOwner +
+            ", toInvoke=" + toInvoke +
+            '}';
+    }
+    public String getName() {
+        return new MethodId(toInvoke).getMethodName();
+    }
+
+    public long getTimeout() {
+        return timeout;
+    }
+
+    @Override
+    public Object execute(Object[] parameters) {
+        throw new UnsupportedOperationException("not implemented yet");
+    }
+}

--- a/client/src/main/java/com/flipkart/flux/client/registry/ExecutableRegistry.java
+++ b/client/src/main/java/com/flipkart/flux/client/registry/ExecutableRegistry.java
@@ -25,9 +25,9 @@ import java.lang.reflect.Method;
  * */
 public interface ExecutableRegistry {
     /* Retrieve an executable corresponding to a task given the taskIdentifier */
-    public Executable getTask(String taskIdentifier);
+    Executable getTask(String taskIdentifier);
     /* Retrieve an executable hook given the hookIdentifier */
-    public Method getHook(String hookIdentifier);
+    Method getHook(String hookIdentifier);
     /* register a task executable against a given identifier. This operation must be idempotent */
-    public void registerTask(String taskIdentifier, Executable method);
+    void registerTask(String taskIdentifier, Executable method);
 }

--- a/client/src/main/java/com/flipkart/flux/client/registry/LocalExecutableRegistryImpl.java
+++ b/client/src/main/java/com/flipkart/flux/client/registry/LocalExecutableRegistryImpl.java
@@ -39,7 +39,7 @@ public class LocalExecutableRegistryImpl implements ExecutableRegistry {
         this(new ConcurrentHashMap<>(),injector);
     }
 
-    public LocalExecutableRegistryImpl(Map<String, Executable> identifierToMethodMap,Injector injector) {
+    public LocalExecutableRegistryImpl(Map<String, Executable> identifierToMethodMap, Injector injector) {
         this.identifierToMethodMap = identifierToMethodMap  ;
         this.injector = injector;
     }
@@ -60,7 +60,7 @@ public class LocalExecutableRegistryImpl implements ExecutableRegistry {
                 final Object classInstance = this.injector.getInstance(Class.forName(methodId.getClassName()));
                 final Method methodToInvoke = classInstance.getClass().getDeclaredMethod(methodId.getMethodName(), methodId.getParameterTypes());
                 final Task taskAnnotation = methodToInvoke.getAnnotationsByType(Task.class)[0];
-                return new Executable(classInstance, methodToInvoke, taskAnnotation.timeout());
+                return new ExecutableImpl(classInstance, methodToInvoke, taskAnnotation.timeout());
             } catch (ClassNotFoundException | NoSuchMethodException e) {
                 throw new UnknownIdentifierException("Could not load method corresponding to the given task identifier:" + taskIdentifier);
             }

--- a/client/src/test/java/com/flipkart/flux/client/intercept/E2EWorkflowTest.java
+++ b/client/src/test/java/com/flipkart/flux/client/intercept/E2EWorkflowTest.java
@@ -58,6 +58,7 @@ public class E2EWorkflowTest {
     @Inject
     ExecutableRegistry executableRegistry;
 
+
     @Test
     public void test_e2eSubmissionOfAWorkflow() throws Exception {
         simpleWorkflowForTest.simpleDummyWorkflow("String one",2);

--- a/client/src/test/java/com/flipkart/flux/client/intercept/TaskInterceptorTest.java
+++ b/client/src/test/java/com/flipkart/flux/client/intercept/TaskInterceptorTest.java
@@ -16,6 +16,7 @@ package com.flipkart.flux.client.intercept;
 
 import com.flipkart.flux.api.EventDefinition;
 import com.flipkart.flux.client.registry.Executable;
+import com.flipkart.flux.client.registry.ExecutableImpl;
 import com.flipkart.flux.client.registry.ExecutableRegistry;
 import com.flipkart.flux.client.runtime.LocalContext;
 import com.flipkart.flux.client.utils.TestUtil;
@@ -30,7 +31,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -85,7 +85,7 @@ public class TaskInterceptorTest {
     @Test
     public void shouldRegisterTaskMethodsWithRegistry() throws Throwable {
         taskInterceptor.invoke(TestUtil.dummyInvocation(simpleWorkflowForTest.getClass().getDeclaredMethod("simpleStringModifyingTask", String.class), simpleWorkflowForTest));
-        final Executable expectedExecutable = new Executable(simpleWorkflowForTest,simpleWorkflowForTest.getClass().getDeclaredMethod("simpleStringModifyingTask", String.class), 2000l);
+        final Executable expectedExecutable = new ExecutableImpl(simpleWorkflowForTest,simpleWorkflowForTest.getClass().getDeclaredMethod("simpleStringModifyingTask", String.class), 2000l);
         verify(executableRegistry,times(1)).registerTask("com.flipkart.flux.client.intercept.SimpleWorkflowForTest_simpleStringModifyingTask_java.lang.String_java.lang.String",expectedExecutable);
     }
 }

--- a/client/src/test/java/com/flipkart/flux/client/registry/LocalExecutableRegistryImplTest.java
+++ b/client/src/test/java/com/flipkart/flux/client/registry/LocalExecutableRegistryImplTest.java
@@ -27,8 +27,9 @@ import org.mockito.runners.MockitoJUnitRunner;
 import java.util.HashMap;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class LocalExecutableRegistryImplTest {
@@ -53,22 +54,22 @@ public class LocalExecutableRegistryImplTest {
 
     @Test
     public void testRegisterNewTask_shouldStoreExecutableInCache() throws Exception {
-        localExecutableRegistry.registerTask("fooBar", new Executable(simpleWorkflowForTest,simpleWorkflowForTest.getClass().getDeclaredMethod("simpleStringModifyingTask", String.class), 2000l));
+        localExecutableRegistry.registerTask("fooBar", new ExecutableImpl(simpleWorkflowForTest,simpleWorkflowForTest.getClass().getDeclaredMethod("simpleStringModifyingTask", String.class), 2000l));
         assertThat(identifierToMethodMap.containsKey("fooBar")).isTrue();
-        assertThat(identifierToMethodMap.get("fooBar")).isEqualTo(new Executable(simpleWorkflowForTest, simpleWorkflowForTest.getClass().getDeclaredMethod("simpleStringModifyingTask", String.class), 2000l));
+        assertThat(identifierToMethodMap.get("fooBar")).isEqualTo(new ExecutableImpl(simpleWorkflowForTest, simpleWorkflowForTest.getClass().getDeclaredMethod("simpleStringModifyingTask", String.class), 2000l));
     }
 
     @Test
     public void testRegisterNewTask_gracefullyHandleDuplicates() throws Exception {
-        localExecutableRegistry.registerTask("fooBar",new Executable(simpleWorkflowForTest,simpleWorkflowForTest.getClass().getDeclaredMethod("simpleStringModifyingTask", String.class), 2000l));
-        localExecutableRegistry.registerTask("fooBar",new Executable(simpleWorkflowForTest,simpleWorkflowForTest.getClass().getDeclaredMethod("simpleStringModifyingTask", String.class), 2000l));
+        localExecutableRegistry.registerTask("fooBar",new ExecutableImpl(simpleWorkflowForTest,simpleWorkflowForTest.getClass().getDeclaredMethod("simpleStringModifyingTask", String.class), 2000l));
+        localExecutableRegistry.registerTask("fooBar",new ExecutableImpl(simpleWorkflowForTest,simpleWorkflowForTest.getClass().getDeclaredMethod("simpleStringModifyingTask", String.class), 2000l));
         assertThat(identifierToMethodMap.containsKey("fooBar")).isTrue();
-        assertThat(identifierToMethodMap.get("fooBar")).isEqualTo(new Executable(simpleWorkflowForTest,simpleWorkflowForTest.getClass().getDeclaredMethod("simpleStringModifyingTask", String.class), 2000l));
+        assertThat(identifierToMethodMap.get("fooBar")).isEqualTo(new ExecutableImpl(simpleWorkflowForTest,simpleWorkflowForTest.getClass().getDeclaredMethod("simpleStringModifyingTask", String.class), 2000l));
     }
 
     @Test
     public void testTaskRetrieval_shouldRetrieveRegisteredExecutables() throws Exception {
-        final Executable givenExecutable = new Executable(simpleWorkflowForTest, simpleWorkflowForTest.getClass().getDeclaredMethod("simpleStringModifyingTask", String.class), 2000l);
+        final Executable givenExecutable = new ExecutableImpl(simpleWorkflowForTest, simpleWorkflowForTest.getClass().getDeclaredMethod("simpleStringModifyingTask", String.class), 2000l);
         localExecutableRegistry.registerTask("fooBar", givenExecutable);
         assertThat(localExecutableRegistry.getTask("fooBar")).isEqualTo(givenExecutable);
     }
@@ -79,7 +80,7 @@ public class LocalExecutableRegistryImplTest {
         when(injector.getInstance(any(Class.class))).thenReturn(simpleWorkflowForTest);
 
         /* actual test */
-        final Executable expectedExecutable = new Executable(simpleWorkflowForTest, simpleWorkflowForTest.getClass().getDeclaredMethod("simpleStringModifyingTask", String.class), 2000l);
+        final Executable expectedExecutable = new ExecutableImpl(simpleWorkflowForTest, simpleWorkflowForTest.getClass().getDeclaredMethod("simpleStringModifyingTask", String.class), 2000l);
         assertThat(
             localExecutableRegistry.getTask("com.flipkart.flux.client.intercept.SimpleWorkflowForTest_simpleStringModifyingTask_java.lang.String_java.lang.String"))
         .isEqualTo(expectedExecutable);

--- a/task/pom.xml
+++ b/task/pom.xml
@@ -138,6 +138,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.typesafe.akka</groupId>
+            <artifactId>akka-testkit_2.11</artifactId>
+            <version>2.4.6</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.flipkart.polyguice</groupId>
             <artifactId>polyguice-core</artifactId>
             <version>${polyguice.version}</version>

--- a/task/src/main/java/com/flipkart/flux/impl/boot/TaskModule.java
+++ b/task/src/main/java/com/flipkart/flux/impl/boot/TaskModule.java
@@ -1,10 +1,10 @@
 package com.flipkart.flux.impl.boot;
 
+import com.flipkart.flux.impl.task.CustomSuperviseStrategy;
 import com.flipkart.flux.impl.task.registry.EagerInitRouterRegistryImpl;
 import com.flipkart.flux.impl.task.registry.LocalRouterConfigurationRegistryImpl;
 import com.flipkart.flux.impl.task.registry.RouterConfigurationRegistry;
 import com.flipkart.flux.impl.task.registry.RouterRegistry;
-import com.flipkart.polyguice.core.ConfigurationProvider;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 
@@ -36,5 +36,12 @@ public class TaskModule extends AbstractModule {
     public Set<String> getRouterNames() {
         // TODO - this needs to be Provided by the boot util that loads all deployment units
         return new HashSet<String>(){{add("someRouter");add("someRouterWithoutConfig");}};
+    }
+
+    @Provides
+    @Singleton
+    public CustomSuperviseStrategy getSupervisorStrategy() {
+        //todo re-tries to come from config
+        return new CustomSuperviseStrategy(2);
     }
 }

--- a/task/src/main/java/com/flipkart/flux/impl/excpetion/TaskResumableException.java
+++ b/task/src/main/java/com/flipkart/flux/impl/excpetion/TaskResumableException.java
@@ -1,0 +1,7 @@
+package com.flipkart.flux.impl.excpetion;
+
+public class TaskResumableException extends RuntimeException {
+    public TaskResumableException(String message) {
+        super(message);
+    }
+}

--- a/task/src/main/java/com/flipkart/flux/impl/task/AkkaTask.java
+++ b/task/src/main/java/com/flipkart/flux/impl/task/AkkaTask.java
@@ -53,6 +53,11 @@ public class AkkaTask extends UntypedActor {
     @Named("HookRouter")
     private Router hookRouter;
 
+	//todo to be removed when we have figured out the way to inject registry in actor. And corresponding unit test can be changed accordingly.
+	public void setTaskRegistry(TaskRegistry taskRegistry) {
+		this.taskRegistry = taskRegistry;
+	}
+
 	/**
 	 * The Akka Actor callback method for processing the Task
 	 * @see akka.actor.UntypedActor#onReceive(java.lang.Object)
@@ -101,5 +106,6 @@ public class AkkaTask extends UntypedActor {
 			}
 		}
 	}
+
 
 }

--- a/task/src/main/java/com/flipkart/flux/impl/task/AkkaTask.java
+++ b/task/src/main/java/com/flipkart/flux/impl/task/AkkaTask.java
@@ -13,17 +13,6 @@
 
 package com.flipkart.flux.impl.task;
 
-import java.util.List;
-
-import javax.inject.Inject;
-import javax.inject.Named;
-
-import com.flipkart.flux.domain.Event;
-import com.flipkart.flux.domain.Task;
-import com.flipkart.flux.impl.message.HookAndEvents;
-import com.flipkart.flux.impl.message.TaskAndEvents;
-import com.netflix.hystrix.HystrixCommand;
-
 import akka.actor.ActorRef;
 import akka.actor.Props;
 import akka.actor.Terminated;
@@ -32,6 +21,15 @@ import akka.event.Logging;
 import akka.event.LoggingAdapter;
 import akka.routing.ActorRefRoutee;
 import akka.routing.Router;
+import com.flipkart.flux.domain.Event;
+import com.flipkart.flux.domain.Task;
+import com.flipkart.flux.impl.message.HookAndEvents;
+import com.flipkart.flux.impl.message.TaskAndEvents;
+import com.netflix.hystrix.HystrixCommand;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import java.util.List;
 
 /**
  * <code>AkkaTask</code> is an Akka {@link UntypedActor} that executes {@link Task} instances concurrently. Tasks are executed using a {@link TaskExecutor} where 
@@ -62,6 +60,7 @@ public class AkkaTask extends UntypedActor {
 	@SuppressWarnings("unchecked")
 	public void onReceive(Object message) throws Exception {
 
+		//todo actor can take a call when to throw TaskResumableException
 		if (TaskAndEvents.class.isAssignableFrom(message.getClass())) {
 			TaskAndEvents taskAndEvent = (TaskAndEvents)message;
 		 	AbstractTask task = this.taskRegistry.retrieveTask(taskAndEvent.getTaskIdentifier());

--- a/task/src/main/java/com/flipkart/flux/impl/task/CustomSuperviseStrategy.java
+++ b/task/src/main/java/com/flipkart/flux/impl/task/CustomSuperviseStrategy.java
@@ -1,0 +1,41 @@
+package com.flipkart.flux.impl.task;
+
+import akka.actor.OneForOneStrategy;
+import akka.actor.SupervisorStrategy;
+import akka.japi.Function;
+import com.flipkart.flux.impl.excpetion.TaskResumableException;
+import com.google.inject.Inject;
+import scala.concurrent.duration.Duration;
+
+import static akka.actor.SupervisorStrategy.escalate;
+import static akka.actor.SupervisorStrategy.restart;
+import static akka.actor.SupervisorStrategy.resume;
+import static akka.actor.SupervisorStrategy.stop;
+
+
+public class CustomSuperviseStrategy {
+
+    //todo fine tune these exceptions
+    private Function function = t -> {
+        if (t instanceof TaskResumableException) {
+            return resume();
+        } else if (t instanceof NullPointerException) {
+            return restart();
+        } else if (t instanceof IllegalArgumentException) {
+            return stop();
+        } else {
+            return escalate();
+        }
+    };
+
+    private final SupervisorStrategy strategy;
+
+    @Inject
+    public CustomSuperviseStrategy(int maxNrOfRetries) {
+        strategy = new OneForOneStrategy(maxNrOfRetries, Duration.Inf(),  function);
+    }
+
+    public SupervisorStrategy getStrategy() {
+        return strategy;
+    }
+}

--- a/task/src/main/java/com/flipkart/flux/impl/task/LocalJvmTask.java
+++ b/task/src/main/java/com/flipkart/flux/impl/task/LocalJvmTask.java
@@ -5,8 +5,6 @@ import com.flipkart.flux.domain.Event;
 import com.flipkart.flux.domain.FluxError;
 import javafx.util.Pair;
 
-import java.lang.reflect.Method;
-
 /**
  * A task that can be executed locally within the same JVM
  * @author yogesh.nachnani

--- a/task/src/main/java/com/flipkart/flux/impl/task/TaskExecutor.java
+++ b/task/src/main/java/com/flipkart/flux/impl/task/TaskExecutor.java
@@ -54,6 +54,7 @@ public class TaskExecutor extends HystrixCommand<Event> {
                 		.withExecutionIsolationStrategy(ExecutionIsolationStrategy.THREAD)
                 		.withExecutionTimeoutInMilliseconds(task.getExecutionTimeout())));
 		this.task = task;
+		this.events = events;
 	}
 	
 	/**

--- a/task/src/test/java/com/flipkart/flux/impl/task/AkkaTaskTest.java
+++ b/task/src/test/java/com/flipkart/flux/impl/task/AkkaTaskTest.java
@@ -1,0 +1,90 @@
+package com.flipkart.flux.impl.task;
+
+import akka.actor.ActorSystem;
+import akka.actor.Props;
+import akka.testkit.TestActorRef;
+import com.flipkart.flux.client.registry.Executable;
+import com.flipkart.flux.client.registry.ExecutableRegistry;
+import com.flipkart.flux.domain.Event;
+import com.flipkart.flux.impl.message.TaskAndEvents;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import scala.concurrent.Future;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AkkaTaskTest {
+    @Mock
+    ExecutableRegistry executableRegistry;
+
+    private TaskRegistry taskRegistry;
+
+    @Before
+    public void setUp() throws Exception {
+        taskRegistry = new TaskRegistry(executableRegistry);
+    }
+
+    @Test
+    public void shouldExecuteABasicTask() throws Exception {
+        Config config = ConfigFactory.parseString(
+                "akka.remote.netty.tcp.port=" + 2551).withFallback(
+                ConfigFactory.load());
+
+        ActorSystem actorSystem = ActorSystem.create("CalcSystem", config);
+        final Props props = Props.create(AkkaTask.class);
+        final TestActorRef<AkkaTask> ref = TestActorRef.create(actorSystem, props, "testA");
+        final AkkaTask actor = ref.underlyingActor();
+        Event[] events = new Event[1];
+        events[0] = new Event("name", "type", Event.EventStatus.pending, 1L, new Object(), "es");
+        TaskAndEvents taskAndEvents = new TaskAndEvents("ti", events);
+
+        int counter=0;
+        final TestExecutable givenExecutable = new TestExecutable(counter);
+        when(executableRegistry.getTask(anyString())).thenReturn(givenExecutable);
+
+        actor.setTaskRegistry(taskRegistry);
+
+        //this test is just for functionality check of actor. In actual flow, future might not be used and async testing will need to be done.
+        final Future<Object> future = akka.pattern.Patterns.ask(ref, taskAndEvents, 3);
+        assertTrue(future.isCompleted());
+        assertTrue(givenExecutable.getCounter()==counter+1);
+    }
+
+    class TestExecutable implements Executable {
+
+        private int counter;
+
+        public TestExecutable(int counter) {
+            this.counter = counter;
+        }
+
+        @Override
+        public String getName() {
+            return "test";
+        }
+
+        @Override
+        public long getTimeout() {
+            return 10;
+        }
+
+        @Override
+        public Object execute(Object[] parameters) {
+            return ++counter;
+        }
+
+        public int getCounter() {
+            return counter;
+        }
+    }
+
+
+}

--- a/task/src/test/java/com/flipkart/flux/impl/task/TaskRegistryTest.java
+++ b/task/src/test/java/com/flipkart/flux/impl/task/TaskRegistryTest.java
@@ -2,6 +2,7 @@ package com.flipkart.flux.impl.task;
 
 import com.flipkart.flux.client.intercept.UnknownIdentifierException;
 import com.flipkart.flux.client.registry.Executable;
+import com.flipkart.flux.client.registry.ExecutableImpl;
 import com.flipkart.flux.client.registry.ExecutableRegistry;
 import org.junit.Before;
 import org.junit.Test;
@@ -10,7 +11,6 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -32,7 +32,7 @@ public class TaskRegistryTest {
     @Test
     public void testRetrieve_shouldReturnTaskGivenIdentifier() throws Exception {
         final Object someObject = new Object();
-        final Executable givenExecutable = new Executable(someObject, someObject.getClass().getDeclaredMethod("toString"), 10);
+        final Executable givenExecutable = new ExecutableImpl(someObject, someObject.getClass().getDeclaredMethod("toString"), 10);
         when(executableRegistry.getTask(anyString())).thenReturn(givenExecutable);
         assertThat(taskRegistry.retrieveTask("com.flipkart.flux.impl.SomeWorkflow_simpleStringModifyingTask_java.lang.String_java.lang.String")).isEqualTo(new LocalJvmTask(givenExecutable));
         verify(executableRegistry, times(1)).getTask("com.flipkart.flux.impl.SomeWorkflow_simpleStringModifyingTask_java.lang.String_java.lang.String");

--- a/task/src/test/resources/application.conf
+++ b/task/src/test/resources/application.conf
@@ -1,0 +1,57 @@
+kamon.metric {
+  filters {
+    akka-actor {
+      includes = [ "CalcSystem/user/**" ]
+      excludes = [ "CalcSystem/system/**", "system-name/user/IO-**" ]
+    }
+    trace {
+      includes = [ "**" ]
+      excludes = []
+    }
+    akka-dispatcher {
+      includes = [ "CalcSystem/akka.actor.default-dispatcher" ]
+      excludes = []
+    }
+  }
+}
+
+akka {
+  logLevel = "INFO"
+  log-config-on-start = off
+  actor {
+    provider = "akka.cluster.ClusterActorRefProvider"
+    debug {
+      lifecycle = on
+      unhandled = on
+      fsm = on
+      event-stream = on
+    }
+  }
+  remote {
+    debug {
+      log-sent-messages = on
+      log-received-messages = on
+    }
+    netty.tcp {
+      port = 2551
+      hostname = "localhost"
+    }
+  }
+
+  cluster {
+    seed-nodes = [
+      "akka.tcp://FluxSystem@localhost:2551"]
+
+    # auto downing is NOT safe for production deployments.
+    # you may want to use it during development, read more about it in the docs.
+    #
+    # auto-down-unreachable-after = 10s
+  }
+}
+
+# Disable legacy metrics in akka-cluster.
+akka.cluster.metrics.enabled=off
+
+# Enable metrics extension in akka-cluster-metrics.
+akka.extensions=["akka.cluster.metrics.ClusterMetricsExtension"]
+


### PR DESCRIPTION
*Default strategy of Akka in case of exception is to escalate and leads to re-start of all actors (remote as well). Changed that to use a custom one where based on exception type we can take decision to resume/restart/stop actors
*UT for functionality test of Akka actor. This just checks the functionality and isn't async, which the actual actor will be. Integration test shall check the async behavior.