### PR TITLE
Reflections warning suppression

### DIFF
--- a/runtime/src/main/java/com/flipkart/flux/initializer/FluxInitializer.java
+++ b/runtime/src/main/java/com/flipkart/flux/initializer/FluxInitializer.java
@@ -21,6 +21,7 @@ import com.flipkart.flux.guice.module.HibernateModule;
 import com.flipkart.flux.impl.boot.TaskModule;
 import com.flipkart.flux.impl.task.registry.EagerInitRouterRegistryImpl;
 import com.flipkart.flux.impl.temp.Work;
+import com.flipkart.flux.loader.ReflectionsHelper;
 import com.flipkart.polyguice.core.support.Polyguice;
 import org.eclipse.jetty.server.Server;
 import org.slf4j.Logger;
@@ -109,6 +110,8 @@ public class FluxInitializer {
     private void loadFluxRuntimeContainer() {
         logger.debug("loading flux runtime container");
         final ConfigModule configModule = new ConfigModule(configUrl);
+        //Register URLs with Reflections to suppress the warnings
+        ReflectionsHelper.registerUrlTypes();
         fluxRuntimeContainer.modules(configModule, new HibernateModule(), new ContainerModule(), new TaskModule());
         fluxRuntimeContainer.registerConfigurationProvider(configModule.getConfigProvider());
         fluxRuntimeContainer.prepare();

--- a/runtime/src/main/java/com/flipkart/flux/loader/ReflectionsHelper.java
+++ b/runtime/src/main/java/com/flipkart/flux/loader/ReflectionsHelper.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2012-2016, the original author or authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.flipkart.flux.loader;
+
+import com.google.common.collect.Lists;
+import org.reflections.vfs.Vfs;
+
+import java.net.URL;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Helper class to suppress the warnings of reflections about url types.
+ * Ex log:
+ * [WARN] Reflections - could not create Vfs.Dir from url. ignoring the exception and continuing
+ * org.reflections.ReflectionsException: could not create Vfs.Dir from url, no matching UrlType was found [file:/System/Library/Java/Extensions/libAppleScriptEngine.jnilib]
+ * either use fromURL(final URL url, final List<UrlType> urlTypes) or use the static setDefaultURLTypes(final List<UrlType> urlTypes) or addDefaultURLTypes(UrlType urlType) with your specialized UrlType.
+ *
+ * @author shyam.akirala
+ */
+public class ReflectionsHelper {
+
+    /**
+     * Registers URLs with reflections. Currently our dev machines have .jnilib files in it's class path.
+     * Reflections use of Vfs doesn't recognize the above URLs and logs warns when it sees them. By registering those file endings, we suppress the warns.
+     */
+    public static void registerUrlTypes() {
+
+        final List<Vfs.UrlType> urlTypes = Lists.newArrayList();
+
+        // include a list of file extensions / filenames to be recognized
+        urlTypes.add(new EmptyIfFileEndingsUrlType(".jnilib"));
+
+        urlTypes.addAll(Arrays.asList(Vfs.DefaultUrlTypes.values()));
+
+        Vfs.setDefaultURLTypes(urlTypes);
+    }
+
+    private static class EmptyIfFileEndingsUrlType implements Vfs.UrlType {
+
+        private final List<String> fileEndings;
+
+        private EmptyIfFileEndingsUrlType(final String... fileEndings) {
+
+            this.fileEndings = Lists.newArrayList(fileEndings);
+        }
+
+        public boolean matches(URL url) {
+
+            final String protocol = url.getProtocol();
+            final String externalForm = url.toExternalForm();
+            if (!protocol.equals("file")) {
+                return false;
+            }
+            for (String fileEnding : fileEndings) {
+                if (externalForm.endsWith(fileEnding))
+                    return true;
+            }
+            return false;
+        }
+
+        public Vfs.Dir createDir(final URL url) throws Exception {
+
+            return emptyVfsDir(url);
+        }
+
+        private static Vfs.Dir emptyVfsDir(final URL url) {
+
+            return new Vfs.Dir() {
+                @Override
+                public String getPath() {
+
+                    return url.toExternalForm();
+                }
+
+                @Override
+                public Iterable<Vfs.File> getFiles() {
+
+                    return Collections.emptyList();
+                }
+
+                @Override
+                public void close() {
+
+                }
+            };
+        }
+    }
+}


### PR DESCRIPTION
Added ReflectionHelper file which registers unrecognised file extensions with reflections to suppress the following warnings. Currently added it in Flux code, if needed will move it to Polyguice.


[WARN ] 2016-05-30 17:22:37.596 [main] org.reflections.Reflections - could not create Vfs.Dir from url. ignoring the exception and continuing
org.reflections.ReflectionsException: could not create Vfs.Dir from url, no matching UrlType was found [file:/System/Library/Java/Extensions/libAppleScriptEngine.jnilib]
either use fromURL(final URL url, final List<UrlType> urlTypes) or use the static setDefaultURLTypes(final List<UrlType> urlTypes) or addDefaultURLTypes(UrlType urlType) with your specialized UrlType.
	at org.reflections.vfs.Vfs.fromURL(Vfs.java:109) ~[reflections-0.9.10.jar:?]
	at org.reflections.vfs.Vfs.fromURL(Vfs.java:91) ~[reflections-0.9.10.jar:?]
	at org.reflections.Reflections.scan(Reflections.java:237) ~[reflections-0.9.10.jar:?]
	at org.reflections.Reflections.scan(Reflections.java:204) [reflections-0.9.10.jar:?]
	at org.reflections.Reflections.<init>(Reflections.java:129) [reflections-0.9.10.jar:?]
	at org.reflections.Reflections.<init>(Reflections.java:170) [reflections-0.9.10.jar:?]
	at com.flipkart.polyguice.core.support.AutobindManager.autobind(AutobindManager.java:80) [polyguice-core-1.0.2-SNAPSHOT.jar:?]
	at com.flipkart.polyguice.core.support.PolyguiceModule.configure(PolyguiceModule.java:68) [polyguice-core-1.0.2-SNAPSHOT.jar:?]
	at com.google.inject.AbstractModule.configure(AbstractModule.java:62) [guice-4.0.jar:?]
	at com.google.inject.spi.Elements$RecordingBinder.install(Elements.java:340) [guice-4.0.jar:?]
	at com.google.inject.spi.Elements.getElements(Elements.java:110) [guice-4.0.jar:?]
	at com.google.inject.internal.InjectorShell$Builder.build(InjectorShell.java:138) [guice-4.0.jar:?]
	at com.google.inject.internal.InternalInjectorCreator.build(InternalInjectorCreator.java:104) [guice-4.0.jar:?]
	at com.google.inject.Guice.createInjector(Guice.java:96) [guice-4.0.jar:?]
	at com.google.inject.Guice.createInjector(Guice.java:73) [guice-4.0.jar:?]
	at com.google.inject.Guice.createInjector(Guice.java:62) [guice-4.0.jar:?]
	at com.flipkart.polyguice.core.support.Polyguice.prepare(Polyguice.java:108) [polyguice-core-1.0.2-SNAPSHOT.jar:?]
	at com.flipkart.flux.initializer.FluxInitializer.loadFluxRuntimeContainer(FluxInitializer.java:114) [classes/:?]
	at com.flipkart.flux.initializer.FluxInitializer.start(FluxInitializer.java:121) [classes/:?]
	at com.flipkart.flux.initializer.FluxInitializer.main(FluxInitializer.java:97) [classes/:?]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_60]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_60]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_60]
	at java.lang.reflect.Method.invoke(Method.java:497) ~[?:1.8.0_60]
	at com.intellij.rt.execution.application.AppMain.main(AppMain.java:134) [idea_rt.jar:?]