### PR TITLE
Using a Guice provided configuration for building the flux runtime connector

### DIFF
--- a/client/src/main/java/com/flipkart/flux/client/FluxClientComponentModule.java
+++ b/client/src/main/java/com/flipkart/flux/client/FluxClientComponentModule.java
@@ -35,8 +35,8 @@ import javax.inject.Singleton;
  * <pre><code>
  * {@literal @}Produces
  * {@literal @}Singleton
- *  FluxConfiguration providesFluxConfiguration(AppConfiguration configuration) {
- *    return configuration.getFluxConfiguration();
+ *  FluxClientConfiguration providesFluxClientConfiguration(AppConfiguration configuration) {
+ *    return configuration.getFluxClientConfiguration();
  *  }
  * </code>
  * </pre>

--- a/client/src/main/java/com/flipkart/flux/client/FluxClientComponentModule.java
+++ b/client/src/main/java/com/flipkart/flux/client/FluxClientComponentModule.java
@@ -13,20 +13,35 @@
 
 package com.flipkart.flux.client;
 
+import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+
+import com.flipkart.flux.client.config.FluxClientConfiguration;
 import com.flipkart.flux.client.guice.annotation.IsolatedEnv;
 import com.flipkart.flux.client.registry.ExecutableRegistry;
 import com.flipkart.flux.client.registry.LocalExecutableRegistryImpl;
 import com.flipkart.flux.client.runtime.FluxRuntimeConnector;
 import com.flipkart.flux.client.runtime.FluxRuntimeConnectorHttpImpl;
 import com.flipkart.flux.client.runtime.LocalContext;
-import com.google.inject.AbstractModule;
-import com.google.inject.Provides;
 
 import javax.inject.Singleton;
 
 /**
- * <code>FluxClientComponentModule</code> is a Guice {@link AbstractModule} implementation
- * which wires and provides classes to support task execution.
+ * <code>FluxClientComponentModule</code> is a Guice {@link AbstractModule} implementation which
+ * wires and provides classes to support task execution.
+ *
+ * <p> Ensure that you have a provider for the FluxClientConfiguration in one of your application's
+ * guice Module. Example:
+ * <pre><code>
+ * {@literal @}Produces
+ * {@literal @}Singleton
+ *  FluxConfiguration providesFluxConfiguration(AppConfiguration configuration) {
+ *    return configuration.getFluxConfiguration();
+ *  }
+ * </code>
+ * </pre>
+ * </p>
+ *
  * @author yogesh.nachnani
  * @author shyam.akirala
  */
@@ -39,8 +54,10 @@ public class FluxClientComponentModule extends AbstractModule {
 
     @Provides
     @Singleton
-    public FluxRuntimeConnector provideFluxRuntimeConnector( ){
-        return new FluxRuntimeConnectorHttpImpl(1000l,1000l,"http://localhost:9998/api/machines");
+    public FluxRuntimeConnector provideFluxRuntimeConnector(FluxClientConfiguration configuration) {
+        return new FluxRuntimeConnectorHttpImpl(configuration.getConnectionTimeout(),
+                                                configuration.getSocketTimeout(),
+                                                configuration.getUrl() + "/api/machines");
     }
 
     @Provides

--- a/client/src/main/java/com/flipkart/flux/client/config/FluxClientConfiguration.java
+++ b/client/src/main/java/com/flipkart/flux/client/config/FluxClientConfiguration.java
@@ -2,7 +2,7 @@ package com.flipkart.flux.client.config;
 
 public class FluxClientConfiguration {
 
-  private String url;
+  private String url = "http://localhost:9998";
   private long socketTimeout = 1000;
   private long connectionTimeout = 1000;
 

--- a/client/src/main/java/com/flipkart/flux/client/config/FluxClientConfiguration.java
+++ b/client/src/main/java/com/flipkart/flux/client/config/FluxClientConfiguration.java
@@ -1,0 +1,32 @@
+package com.flipkart.flux.client.config;
+
+public class FluxClientConfiguration {
+
+  private String url;
+  private long socketTimeout = 1000;
+  private long connectionTimeout = 1000;
+
+  public String getUrl() {
+    return url;
+  }
+
+  public void setUrl(String url) {
+    this.url = url;
+  }
+
+  public long getSocketTimeout() {
+    return socketTimeout;
+  }
+
+  public void setSocketTimeout(long socketTimeout) {
+    this.socketTimeout = socketTimeout;
+  }
+
+  public long getConnectionTimeout() {
+    return connectionTimeout;
+  }
+
+  public void setConnectionTimeout(long connectionTimeout) {
+    this.connectionTimeout = connectionTimeout;
+  }
+}

--- a/client/src/main/java/com/flipkart/flux/client/intercept/WorkflowInterceptor.java
+++ b/client/src/main/java/com/flipkart/flux/client/intercept/WorkflowInterceptor.java
@@ -46,7 +46,7 @@ public class WorkflowInterceptor implements MethodInterceptor {
     @Inject
     private LocalContext localContext;
     @Inject
-    private Provider<FluxRuntimeConnector> connector;
+    private Provider<FluxRuntimeConnector> connectorProvider;
 
     private final ObjectMapper objectMapper;
 
@@ -54,10 +54,10 @@ public class WorkflowInterceptor implements MethodInterceptor {
         this.objectMapper = new ObjectMapper();
     }
 
-    public WorkflowInterceptor(LocalContext localContext, Provider<FluxRuntimeConnector> connector) {
+    public WorkflowInterceptor(LocalContext localContext, Provider<FluxRuntimeConnector> connectorProvider) {
         this();
         this.localContext = localContext;
-        this.connector = connector;
+        this.connectorProvider = connectorProvider;
     }
 
     @Override
@@ -70,7 +70,7 @@ public class WorkflowInterceptor implements MethodInterceptor {
             localContext.registerNew(new MethodId(method).toString(), workFlowAnnotations[0].version(), workFlowAnnotations[0].description(),correlationId);
             registerEventsForArguments(invocation.getArguments());
             invocation.proceed();
-            connector.get().submitNewWorkflow(localContext.getStateMachineDef());
+            connectorProvider.get().submitNewWorkflow(localContext.getStateMachineDef());
             return null ; // TODO, return a proxy object
         }
         finally {

--- a/client/src/main/java/com/flipkart/flux/client/intercept/WorkflowInterceptor.java
+++ b/client/src/main/java/com/flipkart/flux/client/intercept/WorkflowInterceptor.java
@@ -26,6 +26,7 @@ import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
 
 import javax.inject.Inject;
+import javax.inject.Provider;
 import javax.inject.Singleton;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -45,7 +46,7 @@ public class WorkflowInterceptor implements MethodInterceptor {
     @Inject
     private LocalContext localContext;
     @Inject
-    private FluxRuntimeConnector connector;
+    private Provider<FluxRuntimeConnector> connector;
 
     private final ObjectMapper objectMapper;
 
@@ -53,7 +54,7 @@ public class WorkflowInterceptor implements MethodInterceptor {
         this.objectMapper = new ObjectMapper();
     }
 
-    public WorkflowInterceptor(LocalContext localContext, FluxRuntimeConnector connector) {
+    public WorkflowInterceptor(LocalContext localContext, Provider<FluxRuntimeConnector> connector) {
         this();
         this.localContext = localContext;
         this.connector = connector;
@@ -69,7 +70,7 @@ public class WorkflowInterceptor implements MethodInterceptor {
             localContext.registerNew(new MethodId(method).toString(), workFlowAnnotations[0].version(), workFlowAnnotations[0].description(),correlationId);
             registerEventsForArguments(invocation.getArguments());
             invocation.proceed();
-            connector.submitNewWorkflow(localContext.getStateMachineDef());
+            connector.get().submitNewWorkflow(localContext.getStateMachineDef());
             return null ; // TODO, return a proxy object
         }
         finally {

--- a/client/src/test/java/com/flipkart/flux/client/intercept/WorkflowInterceptorTest.java
+++ b/client/src/test/java/com/flipkart/flux/client/intercept/WorkflowInterceptorTest.java
@@ -55,7 +55,7 @@ public class WorkflowInterceptorTest {
 
     @Before
     public void setUp() throws Exception {
-        workflowInterceptor = new WorkflowInterceptor(localContext,fluxRuntimeConnector);
+        workflowInterceptor = new WorkflowInterceptor(localContext,() -> fluxRuntimeConnector);
         objectMapper = new ObjectMapper();
     }
 


### PR DESCRIPTION
This configuration will internally come from one of client application's Guice modules. Example of a client provider

```java
@Produces
@Singleton
FluxClientConfiguration provides FluxClientConfiguration(AppConfiguration configuration) {
    return configuration.get FluxClientConfiguration();
}
```