### PR TITLE
Configurable Retry support

### DIFF
--- a/client/src/main/java/com/flipkart/flux/client/exception/FluxRetriableException.java
+++ b/client/src/main/java/com/flipkart/flux/client/exception/FluxRetriableException.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2012-2016, the original author or authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.flipkart.flux.client.exception;
+
+/**
+ * <code>FluxRetriableException</code> indicates an Exception on occurrence of it Flux Runtime retries task execution if
+ * the task has not exhausted the configured number of retries.
+ *
+ * For ex:
+ *      {@literal @}Task(version = 1, retires = 2, timeout = 1000)
+ *      public Object Task1() {
+ *          try {
+ *              // do some stuff
+ *          } catch(UserException ex) {
+ *              throw new FluxRetriableException("message", ex); //wrap the exception with FluxRetriableException to make Flux runtime to retry this task
+ *          }
+ *      }
+ *
+ * @author shyam.akirala
+ */
+public class FluxRetriableException extends RuntimeException {
+
+    /** Constructors */
+    public FluxRetriableException(String message) {
+        super(message);
+    }
+
+    public FluxRetriableException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/client/src/main/java/com/flipkart/flux/client/exception/FluxRetriableException.java
+++ b/client/src/main/java/com/flipkart/flux/client/exception/FluxRetriableException.java
@@ -14,11 +14,11 @@
 package com.flipkart.flux.client.exception;
 
 /**
- * <code>FluxRetriableException</code> indicates an Exception on occurrence of it Flux Runtime retries task execution if
+ * <code>FluxRetriableException</code> indicates an exception on occurrence of it Flux Runtime retries task execution if
  * the task has not exhausted the configured number of retries.
  *
  * For ex:
- *      {@literal @}Task(version = 1, retires = 2, timeout = 1000)
+ *      {@literal @}Task(version = 1, retries = 2, timeout = 1000)
  *      public Object Task1() {
  *          try {
  *              // do some stuff
@@ -29,7 +29,7 @@ package com.flipkart.flux.client.exception;
  *
  * @author shyam.akirala
  */
-public class FluxRetriableException extends RuntimeException {
+public final class FluxRetriableException extends RuntimeException {
 
     /** Constructors */
     public FluxRetriableException(String message) {

--- a/task/src/main/java/com/flipkart/flux/api/core/FluxError.java
+++ b/task/src/main/java/com/flipkart/flux/api/core/FluxError.java
@@ -29,9 +29,9 @@ public class FluxError extends RuntimeException {
 	/** Default Fill in stack trace setting*/
 	private static final boolean DEFAULT_FILL_IN_STACK_TRACE = true;
 
-    /** Enum of errro types*/
+    /** Enum of error types*/
     public enum ErrorType {
-        runtime,timeout
+        runtime,timeout,retriable
     }
     
 	/** The type of error*/

--- a/task/src/main/java/com/flipkart/flux/impl/task/AkkaTask.java
+++ b/task/src/main/java/com/flipkart/flux/impl/task/AkkaTask.java
@@ -100,7 +100,6 @@ public class AkkaTask extends UntypedActor {
      * @see akka.actor.UntypedActor#onReceive(java.lang.Object)
      */
     public void onReceive(Object message) throws Exception {
-        //todo actor can take a call when to throw TaskResumableException
         if (TaskAndEvents.class.isAssignableFrom(message.getClass())) {
             TaskAndEvents taskAndEvent = (TaskAndEvents)message;
             logger.debug("Received directive {}", taskAndEvent);

--- a/task/src/main/java/com/flipkart/flux/impl/task/AkkaTaskSupervisor.java
+++ b/task/src/main/java/com/flipkart/flux/impl/task/AkkaTaskSupervisor.java
@@ -72,10 +72,10 @@ public class AkkaTaskSupervisor {
 						new OneForOneStrategy((int)maxRetries, Duration.Inf(), t -> {
 					        if (t instanceof FluxError) {
 					        	FluxError fe = (FluxError)t;
-					        	if (fe.getType().equals(FluxError.ErrorType.timeout)) {
+					        	if (fe.getType().equals(FluxError.ErrorType.timeout) || fe.getType().equals(FluxError.ErrorType.retriable)) {
 					        		if (fe.getExecutionContextMeta().getAttemptedNoOfRetries() < fe.getExecutionContextMeta().getMaxRetries()) {
-						        		LOGGER.info("Retrying execution of Task. Retry count = {}, Cause = {} ",fe.getExecutionContextMeta().getAttemptedNoOfRetries(), 
-						        				fe.getMessage());
+						        		LOGGER.info("Retrying execution of Task Id: {}. Retry count = {}, Cause = {} ", fe.getExecutionContextMeta().getTaskId(),
+												fe.getExecutionContextMeta().getAttemptedNoOfRetries(), fe.getMessage());
 						        		return SupervisorStrategy.restart();
 					        		} else {
 					        			LOGGER.warn("Aborting retries for Task Id : {}. Retry count exceeded : {}", fe.getExecutionContextMeta().getTaskId(), 


### PR DESCRIPTION
1. Added FluxRetriableException, on its occurrence Flux Runtime tries to do task execution retry if the task has not exhausted the configured number of retries