### PR TITLE
Redriver, Graceful shutdown and other fixes

### DIFF
--- a/redriver/src/main/java/com/flipkart/flux/redriver/scheduler/MessageScheduler.java
+++ b/redriver/src/main/java/com/flipkart/flux/redriver/scheduler/MessageScheduler.java
@@ -21,11 +21,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.inject.Singleton;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.PriorityQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 /**
  * The scheduler uses an in memory priority queue to prioritise messages by their scheduled time
@@ -40,22 +44,25 @@ public class MessageScheduler {
     private static final Logger logger = LoggerFactory.getLogger(MessageScheduler.class);
     private final RedriverRegistry redriverRegistry;
     private SchedulerThread schedulerThread;
+    private ExecutorService persistenceExecutorService;
+    private int noOfPersistenceWorkers;
 
     @Inject
-    public MessageScheduler(MessageManagerService messageManagerService, RedriverRegistry redriverRegistry) {
-        this(messageManagerService, new PriorityQueue<>(new ScheduledMessageComparator()), redriverRegistry);
+    public MessageScheduler(MessageManagerService messageManagerService, RedriverRegistry redriverRegistry, @Named("redriver.persistenceWorkers") int noOfPersistenceWorkers) {
+        this(messageManagerService, new PriorityQueue<>(new ScheduledMessageComparator()), redriverRegistry, noOfPersistenceWorkers);
     }
 
-
-    MessageScheduler(MessageManagerService messageManagerService, PriorityQueue<ScheduledMessage> scheduledMessages, RedriverRegistry redriverRegistry) {
+    MessageScheduler(MessageManagerService messageManagerService, PriorityQueue<ScheduledMessage> scheduledMessages, RedriverRegistry redriverRegistry, int noOfPersistenceWorkers) {
         this.messageManagerService = messageManagerService;
         this.messages = scheduledMessages;
         schedulerThread = new SchedulerThread();
         this.redriverRegistry = redriverRegistry;
+        this.noOfPersistenceWorkers = noOfPersistenceWorkers;
+        persistenceExecutorService = Executors.newFixedThreadPool(noOfPersistenceWorkers);
     }
 
     public void addMessage(ScheduledMessage scheduledMessage) {
-        this.messageManagerService.saveMessage(scheduledMessage);
+        persistenceExecutorService.execute(new PersistenceWorker(scheduledMessage));
         this.messages.add(scheduledMessage);
         this.schedulerThread.resumeJobExecution();
     }
@@ -86,6 +93,7 @@ public class MessageScheduler {
             synchronized (this) {
                 if (schedulerThread.getState() == Thread.State.TERMINATED) {
                     logger.info("Scheduler thread is in Terminated state. Starting a new Scheduler thread.");
+                    persistenceExecutorService = Executors.newFixedThreadPool(noOfPersistenceWorkers);
                     schedulerThread = new SchedulerThread();
                     new RetrieveThread().start();
                     schedulerThread.start();
@@ -98,6 +106,12 @@ public class MessageScheduler {
 
     public void stop() {
         schedulerThread.halt();
+        persistenceExecutorService.shutdown();
+        try {
+            persistenceExecutorService.awaitTermination(5, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            logger.error("Error occurred while terminating Redriver's persistence executor service. Error: " + e.getMessage());
+        }
     }
 
     /**
@@ -210,6 +224,23 @@ public class MessageScheduler {
             synchronized (lock) {
                 lock.notifyAll();
             }
+        }
+    }
+
+    /**
+     * Worker thread used to persist {@link ScheduledMessage} in DB
+     */
+    private class PersistenceWorker implements Runnable {
+
+        ScheduledMessage scheduledMessage;
+
+        PersistenceWorker(ScheduledMessage scheduledMessage) {
+            this.scheduledMessage = scheduledMessage;
+        }
+
+        @Override
+        public void run() {
+            messageManagerService.saveMessage(scheduledMessage);
         }
     }
 }

--- a/redriver/src/main/java/com/flipkart/flux/redriver/scheduler/MessageScheduler.java
+++ b/redriver/src/main/java/com/flipkart/flux/redriver/scheduler/MessageScheduler.java
@@ -48,7 +48,7 @@ public class MessageScheduler {
     private int noOfPersistenceWorkers;
 
     @Inject
-    public MessageScheduler(MessageManagerService messageManagerService, RedriverRegistry redriverRegistry, @Named("redriver.persistenceWorkers") int noOfPersistenceWorkers) {
+    public MessageScheduler(MessageManagerService messageManagerService, RedriverRegistry redriverRegistry, @Named("redriver.noOfPersistenceWorkers") int noOfPersistenceWorkers) {
         this(messageManagerService, new PriorityQueue<>(new ScheduledMessageComparator()), redriverRegistry, noOfPersistenceWorkers);
     }
 

--- a/redriver/src/test/java/com/flipkart/flux/redriver/scheduler/MessageSchedulerTest.java
+++ b/redriver/src/test/java/com/flipkart/flux/redriver/scheduler/MessageSchedulerTest.java
@@ -25,7 +25,6 @@ import org.mockito.runners.MockitoJUnitRunner;
 import java.util.PriorityQueue;
 
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -43,13 +42,15 @@ public class MessageSchedulerTest {
 
     @Before
     public void setUp() throws Exception {
-        messageScheduler = new MessageScheduler(messageManagerService, messages, redriverRegistry);
+        messageScheduler = new MessageScheduler(messageManagerService, messages, redriverRegistry, 10);
     }
 
     @Test
     public void testAddMessage_shouldAddToDbAndPriorityQueue() throws Exception {
         final ScheduledMessage testMessage = new ScheduledMessage(121l, 200l);
         messageScheduler.addMessage(testMessage);
+
+        Thread.sleep(1000);
 
         verify(messageManagerService, times(1)).saveMessage(testMessage);
         verifyNoMoreInteractions(messageManagerService);
@@ -62,7 +63,7 @@ public class MessageSchedulerTest {
         final ScheduledMessage testMessage = new ScheduledMessage(121l, 200l);
         PriorityQueue<ScheduledMessage> localMessageQueue = new PriorityQueue<>();
         localMessageQueue.add(testMessage);
-        messageScheduler = new MessageScheduler(messageManagerService, localMessageQueue, redriverRegistry);
+        messageScheduler = new MessageScheduler(messageManagerService, localMessageQueue, redriverRegistry, 10);
         messageScheduler.removeMessage(121l);
 
         assertTrue(localMessageQueue.isEmpty());
@@ -74,7 +75,7 @@ public class MessageSchedulerTest {
     @Test
     public void testRemoveMessage_shouldBeGracefullInFaceOfUnknownMessageId() throws Exception {
         final PriorityQueue<ScheduledMessage> localMessageQueue = new PriorityQueue<>();
-        messageScheduler = new MessageScheduler(messageManagerService, localMessageQueue, redriverRegistry);
+        messageScheduler = new MessageScheduler(messageManagerService, localMessageQueue, redriverRegistry, 10);
         messageScheduler.removeMessage(123l);
         assertTrue(localMessageQueue.isEmpty());
         verifyZeroInteractions(messageManagerService);
@@ -82,7 +83,7 @@ public class MessageSchedulerTest {
 
     @Test
     public void testScheduledExecution() throws Exception {
-        messageScheduler =  new MessageScheduler(messageManagerService,redriverRegistry);
+        messageScheduler =  new MessageScheduler(messageManagerService,redriverRegistry, 10);
         final long currTime = System.currentTimeMillis();
         messageScheduler.addMessage(new ScheduledMessage(121l, currTime+1000l));
         messageScheduler.addMessage(new ScheduledMessage(122l, currTime+1000l));
@@ -102,7 +103,7 @@ public class MessageSchedulerTest {
 
     @Test
     public void testRemovalAfterExecution() throws Exception {
-        messageScheduler =  new MessageScheduler(messageManagerService,redriverRegistry);
+        messageScheduler =  new MessageScheduler(messageManagerService,redriverRegistry, 10);
         final long currTime = System.currentTimeMillis();
         final ScheduledMessage testMessage1 = new ScheduledMessage(121l, currTime + 800l);
         final ScheduledMessage testMessage2 = new ScheduledMessage(122l, currTime + 800l);

--- a/runtime/src/main/java/com/flipkart/flux/controller/WorkFlowExecutionController.java
+++ b/runtime/src/main/java/com/flipkart/flux/controller/WorkFlowExecutionController.java
@@ -204,8 +204,8 @@ public class WorkFlowExecutionController {
             String routerName = taskName.substring(0, secondUnderscorePosition == -1 ? taskName.length() : secondUnderscorePosition); //the name of router would be classFQN_taskMethodName
             ActorRef router = this.routerRegistry.getRouter(routerName);
 
-            logger.info("Sending msg to router: {} to execute state machine: {} task: {}", router.path(), stateMachineInstanceId, msg.getTaskId());
             router.tell(msg, ActorRef.noSender());
+            logger.info("Sending msg to router: {} to execute state machine: {} task: {}", router.path(), stateMachineInstanceId, msg.getTaskId());
         }));
     }
 

--- a/runtime/src/main/java/com/flipkart/flux/initializer/FluxInitializer.java
+++ b/runtime/src/main/java/com/flipkart/flux/initializer/FluxInitializer.java
@@ -112,6 +112,8 @@ public class FluxInitializer {
                 new TaskModule(),
                 new FluxClientInterceptorModule()
         );
+        //scans package com.flipkart.flux for polyguice specific annotations like @Bindable, @Component etc.
+        fluxRuntimeContainer.scanPackage("com.flipkart.flux");
         fluxRuntimeContainer.registerConfigurationProvider(configModule.getConfigProvider());
         fluxRuntimeContainer.prepare();
     }

--- a/runtime/src/main/resources/packaged/configuration.yml
+++ b/runtime/src/main/resources/packaged/configuration.yml
@@ -43,13 +43,13 @@ runtime:
     name: FluxSystem
     configname: application.conf
     maxGatewayActorCreateRetries : 10
-    noOfRedriverWorkers : 50
 
 redriver:
   batchdelete:
     batchsize: 50
     intervalms: 1000
-  persistenceWorkers: 10
+  noOfRedriverWorkers : 50
+  noOfPersistenceWorkers: 10
 
 deploymentType: directory
 deploymentUnitsPath: "/tmp/workflows/"

--- a/runtime/src/main/resources/packaged/configuration.yml
+++ b/runtime/src/main/resources/packaged/configuration.yml
@@ -49,6 +49,7 @@ redriver:
   batchdelete:
     batchsize: 50
     intervalms: 1000
+  persistenceWorkers: 10
 
 deploymentType: directory
 deploymentUnitsPath: "/tmp/workflows/"

--- a/task/src/main/java/com/flipkart/flux/impl/redriver/AkkaRedriverRegistryImpl.java
+++ b/task/src/main/java/com/flipkart/flux/impl/redriver/AkkaRedriverRegistryImpl.java
@@ -54,7 +54,7 @@ public class AkkaRedriverRegistryImpl implements RedriverRegistry, Initializable
      */
     @Inject    
     public AkkaRedriverRegistryImpl(ActorSystemManager actorSystemManager, 
-    		@Named("runtime.actorsystem.noOfRedriverWorkers") int noOfRedriverWorkers) {
+    		@Named("redriver.noOfRedriverWorkers") int noOfRedriverWorkers) {
     	this.actorSystemManager = actorSystemManager;
     	this.noOfRedriverWorkers = noOfRedriverWorkers;
     }

--- a/task/src/main/java/com/flipkart/flux/impl/redriver/AkkaRedriverTask.java
+++ b/task/src/main/java/com/flipkart/flux/impl/redriver/AkkaRedriverTask.java
@@ -28,7 +28,6 @@ import com.flipkart.flux.redriver.scheduler.MessageScheduler;
 import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * <code>AkkaRedriverTask</code> is an Akka {@link UntypedActor} that uses a cluster singleton scheduler to execute redrivers for
@@ -41,9 +40,6 @@ public class AkkaRedriverTask extends UntypedActor {
 	/** Logger instance for this class*/
     private LoggingAdapter logger = Logging.getLogger(getContext().system(), this);
     
-    /** Status to indicate if this instance is the Leader Actor for scheduling*/
-    private AtomicBoolean isLeader = new AtomicBoolean(false);
-
 	/** The Router instance that manages local redriver task execution Actors */
 	private Router router;
 

--- a/task/src/main/resources/application.conf
+++ b/task/src/main/resources/application.conf
@@ -41,7 +41,7 @@ akka {
  
   cluster {
     seed-nodes = [
-      "akka.tcp://FluxSystem@localhost:2551"]
+      "akka.tcp://FluxSystem@localhost:2551", "akka.tcp://FluxSystem@localhost:2552"]
 
     # auto downing is NOT safe for production deployments.
     # you may want to use it during development, read more about it in the docs.

--- a/task/src/main/resources/application.conf
+++ b/task/src/main/resources/application.conf
@@ -41,7 +41,7 @@ akka {
  
   cluster {
     seed-nodes = [
-      "akka.tcp://FluxSystem@localhost:2551", "akka.tcp://FluxSystem@localhost:2552"]
+      "akka.tcp://FluxSystem@localhost:2551"]
 
     # auto downing is NOT safe for production deployments.
     # you may want to use it during development, read more about it in the docs.


### PR DESCRIPTION
1. Persistence worker thread pool to save ScheduledMessages in db
2. Graceful shutdown of MessageManagerService
3. Scan com.flipkart.flux package for polyguice specific annotations
4. Graceful shutdown of Akka Actor system
5. Run Redriver on the node which is holding RedriverTask cluster
singleton instance
6. key changes in configuration.yml 