### PR TITLE
using jetty configs, instead of default provided by factory

### DIFF
--- a/runtime/src/main/java/com/flipkart/flux/guice/module/ContainerModule.java
+++ b/runtime/src/main/java/com/flipkart/flux/guice/module/ContainerModule.java
@@ -149,7 +149,6 @@ public class ContainerModule extends AbstractModule {
 							 @Named("Api.service.selectors") int selectorThreads,
 							 @Named("Api.service.workers") int maxWorkerThreads,
 							 ObjectMapper objectMapper, MetricRegistry metricRegistry) throws URISyntaxException, UnknownHostException {
-		//todo-ashish figure out some way of setting acceptor/worker threads
 		JacksonJaxbJsonProvider provider = new JacksonJaxbJsonProvider();
 		provider.setMapper(objectMapper);
 		resourceConfig.register(provider);

--- a/runtime/src/main/java/com/flipkart/flux/initializer/OrderedComponentBooter.java
+++ b/runtime/src/main/java/com/flipkart/flux/initializer/OrderedComponentBooter.java
@@ -60,9 +60,10 @@ public class OrderedComponentBooter implements Initializable {
         if (!this.actorSystemManager.isInitialised()) {
             throw new RuntimeException("Actor System should have been initialised by now. WTF!!");
         }
-        /* Bring up the API server */
-        logger.debug("loading API server");
+
         try {
+             /* Bring up the API server */
+            logger.debug("loading API server");
             apiServer.start();
             logger.debug("API server started. Say Hello!");
         /* Bring up the Dashboard server */

--- a/runtime/src/main/resources/packaged/configuration.yml
+++ b/runtime/src/main/resources/packaged/configuration.yml
@@ -39,9 +39,9 @@ Dashboard:
 
 Api:
   service.port: 9998
-  service.acceptors: 5
-  service.selectors: 10
-  service.workers: 25
+  service.acceptors: 4
+  service.selectors: 4
+  service.workers: 200
 
 routers:
   default:


### PR DESCRIPTION
Making API Jetty Server configurable with worker, acceptor and selector threads.