### PR TITLE
Support for workflow cancellation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Additionally, you can also inspect individual state machine execution DAGs and a
 
 <img src="https://github.com/flipkart-incubator/flux/raw/master/docs/audit_records.png" width="500">
 
-Visit https://www.youtube.com/watch?v=DxyNcntnVzQ&feature=youtu.be to see how Flux state machine instance graph and audit look like.
+Click [here](https://drive.google.com/file/d/0BxBoQMKaBB04NzRYQXRXdThrNXM/view?usp=sharing) to see how Flux state machine instance graph and audit look like.
 
 ## Documentation and Examples
 Flux examples are under "examples" module. Each example can be run independently. Flux has very few dependencies and the simplest

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>com.flipkart</groupId>
         <artifactId>flux</artifactId>
-        <version>1.1.1-SNAPSHOT</version>
+        <version>1.1.2-SNAPSHOT</version>
     </parent>
 
     <groupId>com.flipkart.flux</groupId>
     <artifactId>api</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>1.1.2-SNAPSHOT</version>
     <name>api</name>
     <url>http://maven.apache.org</url>
 

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>com.flipkart</groupId>
         <artifactId>flux</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
     </parent>
 
     <groupId>com.flipkart.flux</groupId>
     <artifactId>api</artifactId>
-    <version>1.1-SNAPSHOT</version>
+    <version>1.1.1-SNAPSHOT</version>
     <name>api</name>
     <url>http://maven.apache.org</url>
 

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>com.flipkart</groupId>
         <artifactId>flux</artifactId>
-        <version>1.1.1-SNAPSHOT</version>
+        <version>1.1.2-SNAPSHOT</version>
     </parent>
     
     <groupId>com.flipkart.flux</groupId>
     <artifactId>client</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>1.1.2-SNAPSHOT</version>
     <name>client</name>
     <url>http://maven.apache.org</url>
 

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>com.flipkart</groupId>
         <artifactId>flux</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
     </parent>
     
     <groupId>com.flipkart.flux</groupId>
     <artifactId>client</artifactId>
-    <version>1.1-SNAPSHOT</version>
+    <version>1.1.1-SNAPSHOT</version>
     <name>client</name>
     <url>http://maven.apache.org</url>
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>com.flipkart</groupId>
         <artifactId>flux</artifactId>
-        <version>1.1.1-SNAPSHOT</version>
+        <version>1.1.2-SNAPSHOT</version>
     </parent>
 
     <groupId>com.flipkart.flux</groupId>
     <artifactId>common</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>1.1.2-SNAPSHOT</version>
     <name>common</name>
     <url>http://maven.apache.org</url>
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>com.flipkart</groupId>
         <artifactId>flux</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
     </parent>
 
     <groupId>com.flipkart.flux</groupId>
     <artifactId>common</artifactId>
-    <version>1.1-SNAPSHOT</version>
+    <version>1.1.1-SNAPSHOT</version>
     <name>common</name>
     <url>http://maven.apache.org</url>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>com.flipkart</groupId>
         <artifactId>flux</artifactId>
-        <version>1.1.1-SNAPSHOT</version>
+        <version>1.1.2-SNAPSHOT</version>
     </parent>
     
     <groupId>com.flipkart.flux</groupId>
     <artifactId>examples</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>1.1.2-SNAPSHOT</version>
     <name>examples</name>
     <url>http://maven.apache.org</url>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>com.flipkart</groupId>
         <artifactId>flux</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
     </parent>
     
     <groupId>com.flipkart.flux</groupId>
     <artifactId>examples</artifactId>
-    <version>1.1-SNAPSHOT</version>
+    <version>1.1.1-SNAPSHOT</version>
     <name>examples</name>
     <url>http://maven.apache.org</url>
 

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>com.flipkart</groupId>
         <artifactId>flux</artifactId>
-        <version>1.1.1-SNAPSHOT</version>
+        <version>1.1.2-SNAPSHOT</version>
     </parent>
 
     <groupId>com.flipkart.flux</groupId>
     <artifactId>model</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>1.1.2-SNAPSHOT</version>
     <name>model</name>
     <url>http://maven.apache.org</url>
 

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>com.flipkart</groupId>
         <artifactId>flux</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
     </parent>
 
     <groupId>com.flipkart.flux</groupId>
     <artifactId>model</artifactId>
-    <version>1.1-SNAPSHOT</version>
+    <version>1.1.1-SNAPSHOT</version>
     <name>model</name>
     <url>http://maven.apache.org</url>
 

--- a/model/src/main/java/com/flipkart/flux/domain/StateMachine.java
+++ b/model/src/main/java/com/flipkart/flux/domain/StateMachine.java
@@ -50,6 +50,10 @@ public class StateMachine {
     @JoinColumn(name = "stateMachineId")
     private Set<State> states;
 
+    /** Status of the state machine, denotes whether it is active or cancelled */
+    @Enumerated(EnumType.STRING)
+    private StateMachineStatus status;
+
     /* maintained */
     /** Current states of this state machine*/
     @Transient
@@ -75,6 +79,7 @@ public class StateMachine {
         this.description = description;
         this.states = states;
         this.correlationId = correlationId;
+        this.status = StateMachineStatus.active;
     }
 
     /** Accessor/Mutator methods */
@@ -104,6 +109,12 @@ public class StateMachine {
     }
     public Set<State> getStates() {
         return states;
+    }
+    public StateMachineStatus getStatus() {
+        return status;
+    }
+    public void setStatus(StateMachineStatus status) {
+        this.status = status;
     }
     public Timestamp getCreatedAt() {
         return createdAt;

--- a/model/src/main/java/com/flipkart/flux/domain/StateMachineStatus.java
+++ b/model/src/main/java/com/flipkart/flux/domain/StateMachineStatus.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2012-2016, the original author or authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.flipkart.flux.domain;
+
+/**
+ * <code>StateMachineStatus</code> dentoes whether a state machine is active or cancelled
+ * @author shyam.akirala
+ */
+public enum StateMachineStatus {
+    active, cancelled; // possible states for a state machine
+}

--- a/persistence-mysql/pom.xml
+++ b/persistence-mysql/pom.xml
@@ -9,12 +9,12 @@
     <parent>
         <groupId>com.flipkart</groupId>
         <artifactId>flux</artifactId>
-        <version>1.1.1-SNAPSHOT</version>
+        <version>1.1.2-SNAPSHOT</version>
     </parent>
 
     <groupId>com.flipkart.flux</groupId>
     <artifactId>persistence-mysql</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>1.1.2-SNAPSHOT</version>
     <name>persistence-mysql</name>
     <url>http://maven.apache.org</url>
 

--- a/persistence-mysql/pom.xml
+++ b/persistence-mysql/pom.xml
@@ -9,12 +9,12 @@
     <parent>
         <groupId>com.flipkart</groupId>
         <artifactId>flux</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
     </parent>
 
     <groupId>com.flipkart.flux</groupId>
     <artifactId>persistence-mysql</artifactId>
-    <version>1.1-SNAPSHOT</version>
+    <version>1.1.1-SNAPSHOT</version>
     <name>persistence-mysql</name>
     <url>http://maven.apache.org</url>
 

--- a/persistence-mysql/src/main/resources/flux/migrations/005_add_status_to_StateMachines_table.sql
+++ b/persistence-mysql/src/main/resources/flux/migrations/005_add_status_to_StateMachines_table.sql
@@ -1,0 +1,5 @@
+--liquibase formatted sql
+
+--changeset shyam.akirala:5 runOnChange:false
+
+ALTER TABLE `StateMachines` ADD COLUMN `status` varchar(50) DEFAULT NULL;

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     
     <groupId>com.flipkart</groupId>
     <artifactId>flux</artifactId>
-    <version>1.1-SNAPSHOT</version>
+    <version>1.1.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>flux</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     
     <groupId>com.flipkart</groupId>
     <artifactId>flux</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>1.1.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>flux</name>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>com.flipkart</groupId>
         <artifactId>flux</artifactId>
-        <version>1.1.1-SNAPSHOT</version>
+        <version>1.1.2-SNAPSHOT</version>
     </parent>
 
     <groupId>com.flipkart.flux</groupId>
     <artifactId>runtime</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>1.1.2-SNAPSHOT</version>
     <name>runtime</name>
     <url>http://maven.apache.org</url>
 

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>com.flipkart</groupId>
         <artifactId>flux</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
     </parent>
 
     <groupId>com.flipkart.flux</groupId>
     <artifactId>runtime</artifactId>
-    <version>1.1-SNAPSHOT</version>
+    <version>1.1.1-SNAPSHOT</version>
     <name>runtime</name>
     <url>http://maven.apache.org</url>
 

--- a/runtime/src/main/java/com/flipkart/flux/controller/FSMVisualizationController.java
+++ b/runtime/src/main/java/com/flipkart/flux/controller/FSMVisualizationController.java
@@ -50,7 +50,8 @@ public class FSMVisualizationController {
     @RequestMapping(value = {"/fsmview"}, method = RequestMethod.GET)
     public String fsmview(@RequestParam(value = "fsmid", required = false) String fsmId, ModelMap modelMap, HttpServletRequest request) throws UnknownHostException {
         int fluxApiPort = configInjector.getInstance(Key.get(Integer.class, Names.named("Api.service.port")));
-        String fluxApiUrl = "http://" + InetAddress.getLocalHost().getHostAddress() + ":" + fluxApiPort;
+        String fluxApiHost = InetAddress.getLocalHost().getHostAddress();
+        String fluxApiUrl = System.getProperty("flux.runtimeUrl")== null ? "http://" + fluxApiHost   + ":" + fluxApiPort : System.getProperty("flux.runtimeUrl");
         modelMap.addAttribute("flux_api_url", fluxApiUrl);
         modelMap.addAttribute("fsm_id", (fsmId != null ? fsmId : "null"));
         return FSM_VIEW;

--- a/runtime/src/main/java/com/flipkart/flux/controller/WorkFlowExecutionController.java
+++ b/runtime/src/main/java/com/flipkart/flux/controller/WorkFlowExecutionController.java
@@ -101,23 +101,13 @@ public class WorkFlowExecutionController {
     /**
      * Retrieves the states which are dependant on this event and starts the execution of eligible states (whose all dependencies are met).
      * @param eventData
-     * @param stateMachineInstanceId
-     * @param correlationId
+     * @param stateMachine
      */
-    public Set<State> postEvent(EventData eventData, Long stateMachineInstanceId, String correlationId) {
-        StateMachine stateMachine = null;
-        if (stateMachineInstanceId != null) {
-            stateMachine = retrieveStateMachine(stateMachineInstanceId);
-        } else if(correlationId != null) {
-            stateMachine = retrieveStateMachineByCorrelationId(correlationId);
-            stateMachineInstanceId = (stateMachine == null) ? null : stateMachine.getId();
-        }
-        if(stateMachine == null)
-            throw new UnknownStateMachine("State machine with id: "+stateMachineInstanceId+ " or correlation id " + correlationId + " not found");
+    public Set<State> postEvent(EventData eventData, StateMachine stateMachine) {
         //update event's data and status
-        Event event = eventsDAO.findBySMIdAndName(stateMachineInstanceId, eventData.getName());
+        Event event = eventsDAO.findBySMIdAndName(stateMachine.getId(), eventData.getName());
         if(event == null)
-            throw new IllegalEventException("Event with stateMachineId: "+stateMachineInstanceId+", event name: "+ eventData.getName()+" not found");
+            throw new IllegalEventException("Event with stateMachineId: "+stateMachine.getId()+", event name: "+ eventData.getName()+" not found");
         event.setStatus(Event.EventStatus.triggered);
         event.setEventData(eventData.getData());
         event.setEventSource(eventData.getEventSource());
@@ -129,7 +119,7 @@ public class WorkFlowExecutionController {
         //get the states whose dependencies are met
         final Set<State> dependantStates = context.getDependantStates(eventData.getName());
         logger.debug("These states {} depend on event {}", dependantStates, eventData.getName());
-        Set<State> executableStates = getExecutableStates(dependantStates, stateMachineInstanceId);
+        Set<State> executableStates = getExecutableStates(dependantStates, stateMachine.getId());
         logger.debug("These states {} are now unblocked after event {}", executableStates, eventData.getName());
         //start execution of the above states
         executeStates(stateMachine, executableStates, event);
@@ -218,7 +208,8 @@ public class WorkFlowExecutionController {
         MDC.put(STATE_MACHINE_ID, stateMachine.getId().toString());
         executableStates.forEach((state ->  {
             MDC.put(TASK_ID,state.getId().toString());
-            if(state.getStatus() != Status.completed) {
+            // trigger execution if state is not in completed|cancelled state
+            if(!(state.getStatus() == Status.completed || state.getStatus() == Status.cancelled)) {
                 List<EventData> eventDatas;
                 // If the state is dependant on only one event, that would be the event which came now, in that case don't make a call to DB
                 if (currentEvent != null && state.getDependencies() != null && state.getDependencies().size() == 1 && currentEvent.getName().equals(state.getDependencies().get(0))) {
@@ -255,7 +246,7 @@ public class WorkFlowExecutionController {
                         append(".queueSize").toString());
                 logger.info("Sending msg to router: {} to execute state machine: {} task: {}", router.path(), stateMachine.getId(), msg.getTaskId());
             } else {
-                logger.info("State machine: {} Task: {} execution request got discarded as the task is already completed", state.getStateMachineId(), state.getId());
+                logger.info("State machine: {} Task: {} execution request got discarded as the task is {}", state.getStateMachineId(), state.getId(), state.getStatus());
             }
         }));
     }
@@ -308,5 +299,13 @@ public class WorkFlowExecutionController {
         return !(taskStatus.equals(Status.completed) ||
                 taskStatus.equals(Status.sidelined) ||
                 taskStatus.equals(Status.cancelled));
+    }
+
+    /**
+     * Cancels the corresponding state machine (marks statemachine's and its states' statuses as cancelled)
+     */
+    public void cancelWorkflow(StateMachine stateMachine) {
+        stateMachinesDAO.updateStatus(stateMachine.getId(), StateMachineStatus.cancelled);
+        statesDAO.cancelAllInitializedStates(stateMachine.getId());
     }
 }

--- a/runtime/src/main/java/com/flipkart/flux/controller/WorkFlowExecutionController.java
+++ b/runtime/src/main/java/com/flipkart/flux/controller/WorkFlowExecutionController.java
@@ -306,6 +306,9 @@ public class WorkFlowExecutionController {
      */
     public void cancelWorkflow(StateMachine stateMachine) {
         stateMachinesDAO.updateStatus(stateMachine.getId(), StateMachineStatus.cancelled);
-        statesDAO.cancelAllInitializedStates(stateMachine.getId());
+        stateMachine.getStates().stream().filter(state -> state.getStatus() == Status.initialized).forEach(state -> {
+            this.statesDAO.updateStatus(state.getId(), stateMachine.getId(), Status.cancelled);
+            this.auditDAO.create(new AuditRecord(stateMachine.getId(), state.getId(), state.getAttemptedNoOfRetries(), Status.cancelled, null, null));
+        });
     }
 }

--- a/runtime/src/main/java/com/flipkart/flux/dao/StateMachinesDAOImpl.java
+++ b/runtime/src/main/java/com/flipkart/flux/dao/StateMachinesDAOImpl.java
@@ -15,9 +15,12 @@ package com.flipkart.flux.dao;
 
 import com.flipkart.flux.dao.iface.StateMachinesDAO;
 import com.flipkart.flux.domain.StateMachine;
+import com.flipkart.flux.domain.StateMachineStatus;
+import com.flipkart.flux.domain.Status;
 import com.flipkart.flux.persistence.SessionFactoryContext;
 import com.google.inject.name.Named;
 import org.hibernate.Criteria;
+import org.hibernate.Query;
 import org.hibernate.criterion.Restrictions;
 
 import javax.inject.Inject;
@@ -72,5 +75,14 @@ public class StateMachinesDAOImpl extends AbstractDAO<StateMachine> implements S
     @Transactional
     public StateMachine findByCorrelationId(String correlationId) {
         return (StateMachine) currentSession().createCriteria(StateMachine.class).add(Restrictions.eq("correlationId",correlationId)).uniqueResult();
+    }
+
+    @Override
+    @Transactional
+    public void updateStatus(Long stateMachineId, StateMachineStatus status) {
+        Query query = currentSession().createQuery("update StateMachine set status = :status where id = :stateMachineId");
+        query.setString("status", status != null ? status.toString() : null);
+        query.setLong("stateMachineId", stateMachineId);
+        query.executeUpdate();
     }
 }

--- a/runtime/src/main/java/com/flipkart/flux/dao/StatesDAOImpl.java
+++ b/runtime/src/main/java/com/flipkart/flux/dao/StatesDAOImpl.java
@@ -72,14 +72,6 @@ public class StatesDAOImpl extends AbstractDAO<State> implements StatesDAO {
 
     @Override
     @Transactional
-    public void cancelAllInitializedStates(Long stateMachineId) {
-        Query query = currentSession().createQuery("update State set status = 'cancelled' where stateMachineId = :stateMachineId and status = 'initialized'");
-        query.setLong("stateMachineId", stateMachineId);
-        query.executeUpdate();
-    }
-
-    @Override
-    @Transactional
     public void incrementRetryCount(Long stateId, Long stateMachineId) {
         Query query = currentSession().createQuery("update State set attemptedNoOfRetries = attemptedNoOfRetries + 1 where id = :stateId and stateMachineId = :stateMachineId");
         query.setLong("stateId", stateId);

--- a/runtime/src/main/java/com/flipkart/flux/dao/StatesDAOImpl.java
+++ b/runtime/src/main/java/com/flipkart/flux/dao/StatesDAOImpl.java
@@ -72,6 +72,14 @@ public class StatesDAOImpl extends AbstractDAO<State> implements StatesDAO {
 
     @Override
     @Transactional
+    public void cancelAllInitializedStates(Long stateMachineId) {
+        Query query = currentSession().createQuery("update State set status = 'cancelled' where stateMachineId = :stateMachineId and status = 'initialized'");
+        query.setLong("stateMachineId", stateMachineId);
+        query.executeUpdate();
+    }
+
+    @Override
+    @Transactional
     public void incrementRetryCount(Long stateId, Long stateMachineId) {
         Query query = currentSession().createQuery("update State set attemptedNoOfRetries = attemptedNoOfRetries + 1 where id = :stateId and stateMachineId = :stateMachineId");
         query.setLong("stateId", stateId);

--- a/runtime/src/main/java/com/flipkart/flux/dao/iface/StateMachinesDAO.java
+++ b/runtime/src/main/java/com/flipkart/flux/dao/iface/StateMachinesDAO.java
@@ -14,6 +14,7 @@
 package com.flipkart.flux.dao.iface;
 
 import com.flipkart.flux.domain.StateMachine;
+import com.flipkart.flux.domain.StateMachineStatus;
 
 import java.util.Set;
 
@@ -37,4 +38,7 @@ public interface StateMachinesDAO {
 
     /** Retrieves state machine by it's unique correlationId*/
     StateMachine findByCorrelationId(String correlationId);
+
+    /** Updates status of a state machine*/
+    void updateStatus(Long stateMachineId, StateMachineStatus status);
 }

--- a/runtime/src/main/java/com/flipkart/flux/dao/iface/StatesDAO.java
+++ b/runtime/src/main/java/com/flipkart/flux/dao/iface/StatesDAO.java
@@ -37,6 +37,9 @@ public interface StatesDAO {
     /** Updates rollback status of a state */
     public void updateRollbackStatus(Long stateId, Long stateMachineId, Status rollbackStatus);
 
+    /** Updates statuses of all initialized states of a state machine*/
+    public void cancelAllInitializedStates(Long stateMachineId);
+
     /** Increments the attempted no.of retries of a state by 1 */
     void incrementRetryCount(Long stateId, Long stateMachineId);
 

--- a/runtime/src/main/java/com/flipkart/flux/dao/iface/StatesDAO.java
+++ b/runtime/src/main/java/com/flipkart/flux/dao/iface/StatesDAO.java
@@ -37,9 +37,6 @@ public interface StatesDAO {
     /** Updates rollback status of a state */
     public void updateRollbackStatus(Long stateId, Long stateMachineId, Status rollbackStatus);
 
-    /** Updates statuses of all initialized states of a state machine*/
-    public void cancelAllInitializedStates(Long stateMachineId);
-
     /** Increments the attempted no.of retries of a state by 1 */
     void incrementRetryCount(Long stateId, Long stateMachineId);
 

--- a/runtime/src/main/java/com/flipkart/flux/resource/StateMachineResource.java
+++ b/runtime/src/main/java/com/flipkart/flux/resource/StateMachineResource.java
@@ -148,7 +148,7 @@ public class StateMachineResource {
 
         // 1. Convert to StateMachine (domain object) and save in DB
         StateMachine stateMachine = stateMachinePersistenceService.createStateMachine(stateMachineDefinition);
-        MDC.put(STATE_MACHINE_ID, stateMachine.getId().toString());
+        MDC.clear(); MDC.put(STATE_MACHINE_ID, stateMachine.getId().toString());
         logger.info("Created state machine with Id: {} and correlation Id: {}", stateMachine.getId(), stateMachine.getCorrelationId());
 
         // 2. initialize and start State Machine
@@ -172,7 +172,7 @@ public class StateMachineResource {
                                 @QueryParam("triggerTime") Long triggerTime,
                                 EventData eventData
     ) throws Exception {
-        MDC.put(STATE_MACHINE_ID, machineId);
+        MDC.clear(); MDC.put(STATE_MACHINE_ID, machineId);
 
         if(triggerTime == null) {
             logger.info("Received event: {} for state machine: {}", eventData.getName(), machineId);
@@ -203,7 +203,7 @@ public class StateMachineResource {
     ) throws Exception {
         EventData eventData = eventAndExecutionData.getEventData();
         ExecutionUpdateData executionUpdateData = eventAndExecutionData.getExecutionUpdateData();
-        MDC.put(STATE_MACHINE_ID, machineId);
+        MDC.clear(); MDC.put(STATE_MACHINE_ID, machineId);
         MDC.put(TASK_ID, executionUpdateData.getTaskId().toString());
         logger.info("Received event: {} from state: {} for state machine: {}", eventData.getName(), executionUpdateData.getTaskId(), machineId);
 

--- a/runtime/src/main/java/com/flipkart/flux/resource/StateMachineResource.java
+++ b/runtime/src/main/java/com/flipkart/flux/resource/StateMachineResource.java
@@ -229,7 +229,7 @@ public class StateMachineResource {
             }
 
             if(stateMachine.getStatus() == StateMachineStatus.cancelled) {
-                logger.info("Discarding event as State machine: {} is in cancelled state", stateMachine.getId());
+                logger.info("Discarding event: {} as State machine: {} is in cancelled state", eventData.getName(), stateMachine.getId());
                 return Response.status(Response.Status.ACCEPTED.getStatusCode()).entity("State machine with Id: " + machineId + " is in 'cancelled' state. Discarding the event.").build();
             }
 

--- a/runtime/src/main/java/com/flipkart/flux/resource/StateMachineResource.java
+++ b/runtime/src/main/java/com/flipkart/flux/resource/StateMachineResource.java
@@ -25,7 +25,6 @@ import com.flipkart.flux.dao.iface.StatesDAO;
 import com.flipkart.flux.domain.*;
 import com.flipkart.flux.domain.Status;
 import com.flipkart.flux.exception.IllegalEventException;
-import com.flipkart.flux.exception.UnknownStateMachine;
 import com.flipkart.flux.impl.RAMContext;
 import com.flipkart.flux.metrics.iface.MetricsClient;
 import com.flipkart.flux.representation.IllegalRepresentationException;
@@ -214,15 +213,28 @@ public class StateMachineResource {
 
     private Response postEvent(String machineId, String searchField, EventData eventData) {
         try {
+            StateMachine stateMachine = null;
             if (searchField != null) {
                 if (!searchField.equals(CORRELATION_ID)) {
                     return Response.status(Response.Status.BAD_REQUEST).build();
                 }
-                workFlowExecutionController.postEvent(eventData, null, machineId);
+                stateMachine = stateMachinesDAO.findByCorrelationId(machineId);
             } else {
-                workFlowExecutionController.postEvent(eventData, Long.valueOf(machineId), null);
+                Long stateMachineId = Long.valueOf(machineId);
+                stateMachine = stateMachinesDAO.findById(stateMachineId);
             }
-        } catch (UnknownStateMachine | IllegalEventException ex) {
+
+            if(stateMachine == null) {
+                return Response.status(Response.Status.NOT_FOUND.getStatusCode()).entity("State machine with Id: " + machineId + " not found").build();
+            }
+
+            if(stateMachine.getStatus() == StateMachineStatus.cancelled) {
+                logger.info("Discarding event as State machine: {} is in cancelled state", stateMachine.getId());
+                return Response.status(Response.Status.ACCEPTED.getStatusCode()).entity("State machine with Id: " + machineId + " is in 'cancelled' state. Discarding the event.").build();
+            }
+
+            workFlowExecutionController.postEvent(eventData, stateMachine);
+        } catch (IllegalEventException ex) {
             return Response.status(Response.Status.NOT_FOUND.getStatusCode()).entity(ex.getMessage()).build();
         }
         return Response.status(Response.Status.ACCEPTED).build();
@@ -317,17 +329,6 @@ public class StateMachineResource {
     }
 
     /**
-     * Cancel a machine being executed.*
-     *
-     * @param machineId The machineId to be cancelled
-     */
-    @PUT
-    @Path("/{machineId}/cancel")
-    public void cancelExecution(@PathParam("machineId") Long machineId) {
-        // Trigger cancellation on all currently executing states
-    }
-
-    /**
      * Provides json data to build fsm status graph.
      *
      * @param machineId
@@ -414,6 +415,30 @@ public class StateMachineResource {
     @Transactional
     public Response unsidelineState(@PathParam("stateMachineId") Long stateMachineId, @PathParam("stateId") Long stateId) {
         this.workFlowExecutionController.unsidelineState(stateMachineId, stateId);
+
+        return Response.status(Response.Status.ACCEPTED).build();
+    }
+
+    @PUT
+    @Path("/{stateMachineId}/cancel")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Transactional
+    public Response cancelWorkflow(@PathParam("stateMachineId") String stateMachineId,
+                                       @QueryParam("searchField") String searchField) {
+
+        Long machineId = null;
+        StateMachine stateMachine = null;
+        if(searchField != null && searchField.equals(CORRELATION_ID)) {
+            stateMachine = stateMachinesDAO.findByCorrelationId(stateMachineId);
+        } else {
+            machineId = Long.parseLong(stateMachineId);
+            stateMachine = stateMachinesDAO.findById(machineId);
+        }
+        if(stateMachine == null) {
+            return Response.status(Response.Status.NOT_FOUND).entity("State machine with id: " + stateMachineId + " not found").build();
+        }
+
+        workFlowExecutionController.cancelWorkflow(stateMachine);
 
         return Response.status(Response.Status.ACCEPTED).build();
     }

--- a/runtime/src/main/resources/packaged/configuration.yml
+++ b/runtime/src/main/resources/packaged/configuration.yml
@@ -55,7 +55,7 @@ runtime:
     metrics: false
     name: FluxSystem
     configname: application.conf
-    maxTaskActorCreateRetries : 10
+    maxTaskActorCreateRetries : -1
 
 redriver:
   batchDelete:

--- a/scheduler/pom.xml
+++ b/scheduler/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>com.flipkart</groupId>
         <artifactId>flux</artifactId>
-        <version>1.1.1-SNAPSHOT</version>
+        <version>1.1.2-SNAPSHOT</version>
     </parent>
 
     <groupId>com.flipkart.flux</groupId>
     <artifactId>scheduler</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>1.1.2-SNAPSHOT</version>
     <name>scheduler</name>
     <url>http://maven.apache.org</url>
 

--- a/scheduler/pom.xml
+++ b/scheduler/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>com.flipkart</groupId>
         <artifactId>flux</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
     </parent>
 
     <groupId>com.flipkart.flux</groupId>
     <artifactId>scheduler</artifactId>
-    <version>1.1-SNAPSHOT</version>
+    <version>1.1.1-SNAPSHOT</version>
     <name>scheduler</name>
     <url>http://maven.apache.org</url>
 

--- a/task/pom.xml
+++ b/task/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>com.flipkart</groupId>
         <artifactId>flux</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
     </parent>
 
     <groupId>com.flipkart.flux</groupId>
     <artifactId>task</artifactId>
-    <version>1.1-SNAPSHOT</version>
+    <version>1.1.1-SNAPSHOT</version>
     <name>task</name>
     <url>http://maven.apache.org</url>
 

--- a/task/pom.xml
+++ b/task/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>com.flipkart</groupId>
         <artifactId>flux</artifactId>
-        <version>1.1.1-SNAPSHOT</version>
+        <version>1.1.2-SNAPSHOT</version>
     </parent>
 
     <groupId>com.flipkart.flux</groupId>
     <artifactId>task</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>1.1.2-SNAPSHOT</version>
     <name>task</name>
     <url>http://maven.apache.org</url>
 

--- a/task/src/main/java/com/flipkart/flux/impl/redriver/RedriverRegistryImpl.java
+++ b/task/src/main/java/com/flipkart/flux/impl/redriver/RedriverRegistryImpl.java
@@ -102,7 +102,7 @@ public class RedriverRegistryImpl implements RedriverRegistry, Initializable {
 	 * @see RedriverRegistry#deRegisterTask(java.lang.Long)
 	 */
 	public void deRegisterTask(Long taskId) {
-		MDC.put(TASK_ID,taskId.toString());
+		MDC.clear(); MDC.put(TASK_ID,taskId.toString());
 		logger.debug("DeRegister task : {} with redriver", taskId);
 		redriverMessageService.scheduleForRemoval(taskId);
 	}
@@ -112,7 +112,7 @@ public class RedriverRegistryImpl implements RedriverRegistry, Initializable {
 	 * @see RedriverRegistry#redriveTask(java.lang.Long)
 	 */
 	public void redriveTask(Long taskId) {
-		MDC.put(TASK_ID, taskId.toString());
+		MDC.clear(); MDC.put(TASK_ID, taskId.toString());
 		logger.debug("Redrive task with Id : {} ", taskId);
 		fluxRuntimeConnector.redriveTask(taskId);
 	}

--- a/task/src/main/java/com/flipkart/flux/impl/task/AkkaTask.java
+++ b/task/src/main/java/com/flipkart/flux/impl/task/AkkaTask.java
@@ -177,12 +177,6 @@ public class AkkaTask extends UntypedActor {
                                 cause = cause.getCause();
                             }
                             if (isFluxRetriableException) {
-                                metricsClient.incCounter(new StringBuilder().
-                                        append("stateMachine.").
-                                        append(taskAndEvent.getStateMachineName()).
-                                        append(".task.").
-                                        append(taskAndEvent.getTaskName()).
-                                        append(".queueSize").toString());
                                 // mark the task outcome as execution failure, and the task is retriable
                                 updateExecutionStatus(taskAndEvent, Status.errored, cause.getClass().getName() + " : " + cause.getMessage(), false);
 
@@ -226,7 +220,12 @@ public class AkkaTask extends UntypedActor {
                                 getSelf(),
                                 message,
                                 getContext().system().dispatcher(), null);
-
+                        metricsClient.incCounter(new StringBuilder().
+                                append("stateMachine.").
+                                append(fe.getExecutionContextMeta().getStateMachineName()).
+                                append(".task.").
+                                append(fe.getExecutionContextMeta().getTaskName()).
+                                append(".queueSize").toString());
                     } else {
                         logger.warning("Aborting retries for Task Id : {}. Retry count exceeded : {}", fe.getExecutionContextMeta().getTaskId(),
                                 fe.getExecutionContextMeta().getAttemptedNoOfRetries());


### PR DESCRIPTION
On calling cancel API, all initialized tasks of the workflow and workflow status would be marked as cancelled.

If any event occurs if a workflow is cancelled state, the event would be discarded.