### PR TITLE
Dynamic conditions support

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>com.flipkart</groupId>
         <artifactId>flux</artifactId>
-        <version>1.1.3-SNAPSHOT</version>
+        <version>1.1.4-SNAPSHOT</version>
     </parent>
 
     <groupId>com.flipkart.flux</groupId>
     <artifactId>api</artifactId>
-    <version>1.1.3-SNAPSHOT</version>
+    <version>1.1.4-SNAPSHOT</version>
     <name>api</name>
     <url>http://maven.apache.org</url>
 

--- a/api/src/main/java/com/flipkart/flux/api/EventData.java
+++ b/api/src/main/java/com/flipkart/flux/api/EventData.java
@@ -14,6 +14,7 @@
 package com.flipkart.flux.api;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import java.io.Serializable;
 
@@ -22,6 +23,7 @@ import java.io.Serializable;
  * This is useful for data transfer purpose only.
  * @author shyam.akirala
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class EventData implements Serializable {
 
     /** Name of the event */
@@ -36,6 +38,9 @@ public class EventData implements Serializable {
     /** Source who generated this event, might be state name or external */
     private String eventSource;
 
+    /** Indicates whether this event is cancelled, based on this value runtime decides to cancel the entire path in DAG */
+    private Boolean isCancelled;
+
     /** Used by jackson */
     EventData() {}
 
@@ -45,6 +50,11 @@ public class EventData implements Serializable {
         this.type = type;
         this.data = data;
         this.eventSource = eventSource;
+    }
+
+    public EventData(String name, String type, String data, String eventSource, Boolean isCancelled) {
+        this(name, type, data, eventSource);
+        this.isCancelled = isCancelled;
     }
 
     /** Accessor/Mutator methods*/
@@ -72,6 +82,12 @@ public class EventData implements Serializable {
     public void setEventSource(String eventSource) {
         this.eventSource = eventSource;
     }
+    public Boolean getCancelled() {
+        return isCancelled;
+    }
+    public void setCancelled(Boolean cancelled) {
+        isCancelled = cancelled;
+    }
 
     @Override
     public boolean equals(Object o) {
@@ -81,29 +97,32 @@ public class EventData implements Serializable {
         EventData eventData = (EventData) o;
 
         if (!name.equals(eventData.name)) return false;
-        if (!type.equals(eventData.type)) return false;
+        if (type != null ? !type.equals(eventData.type) : eventData.type != null) return false;
         if (data != null ? !data.equals(eventData.data) : eventData.data != null) return false;
-        if (eventSource != null ? !eventSource.equals(eventData.eventSource) : eventData.eventSource != null) return false;
-        return true;
+        if (eventSource != null ? !eventSource.equals(eventData.eventSource) : eventData.eventSource != null)
+            return false;
+        return isCancelled != null ? isCancelled.equals(eventData.isCancelled) : eventData.isCancelled == null;
     }
 
     @Override
     public int hashCode() {
         int result = name.hashCode();
-        result = 31 * result + type.hashCode();
+        result = 31 * result + (type != null ? type.hashCode() : 0);
         result = 31 * result + (data != null ? data.hashCode() : 0);
         result = 31 * result + (eventSource != null ? eventSource.hashCode() : 0);
+        result = 31 * result + (isCancelled != null ? isCancelled.hashCode() : 0);
         return result;
     }
 
     @Override
     public String toString() {
         return "EventData{" +
-            "data=" + data +
-            ", name='" + name + '\'' +
-            ", type='" + type + '\'' +
-            ", eventSource='" + eventSource + '\'' +
-            '}';
+                "name='" + name + '\'' +
+                ", type='" + type + '\'' +
+                ", data='" + data + '\'' +
+                ", eventSource='" + eventSource + '\'' +
+                ", isCancelled=" + isCancelled +
+                '}';
     }
 
     /**

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>com.flipkart</groupId>
         <artifactId>flux</artifactId>
-        <version>1.1.3-SNAPSHOT</version>
+        <version>1.1.4-SNAPSHOT</version>
     </parent>
     
     <groupId>com.flipkart.flux</groupId>
     <artifactId>client</artifactId>
-    <version>1.1.3-SNAPSHOT</version>
+    <version>1.1.4-SNAPSHOT</version>
     <name>client</name>
     <url>http://maven.apache.org</url>
 

--- a/client/src/main/java/com/flipkart/flux/client/constant/ClientConstants.java
+++ b/client/src/main/java/com/flipkart/flux/client/constant/ClientConstants.java
@@ -21,4 +21,6 @@ public class ClientConstants {
 
     /** String used in forming task and workflow identifiers */
     public static final String _VERSION = "_version";
+
+    public static final String CLIENT = "client";
 }

--- a/client/src/main/java/com/flipkart/flux/client/exception/FluxCancelPathException.java
+++ b/client/src/main/java/com/flipkart/flux/client/exception/FluxCancelPathException.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2012-2016, the original author or authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.flipkart.flux.client.exception;
+
+/**
+ * <code>FluxCancelPathException</code> tells Flux Runtime to cancel the branch the event is going to travel, until a join node encountered.
+ *
+ * For Example:
+ * T1 -------> T2 ------> T3 ------> T4 -------> T5 -------> T9
+ *             |                                             ^
+ *             `--------> T6 ------> T7 -------> T8 --------/
+ *
+ * If task T6 throws this exception, the entire path from T6 until T9 is cancelled. T9 would be executed with the event emitted from task T5.
+ *
+ * This exception allows a user to achieve Dynamic conditions. Inside a task, based on the previous task output he can decide whether to go ahead in that path or stop there itself.
+ *
+ * for the above state machine
+ *
+ * {@literal @}Task(version = 1, retries = 2, timeout = 1000)
+ * public ExampleEvent T6(ExampleEvent event) {
+ *     if(event.exampleProperty()) {
+ *         throw new FluxCancelPathException();
+ *     }
+ * }
+ *
+ * Created by shyam.akirala on 29/08/17.
+ */
+public class FluxCancelPathException extends RuntimeException {
+
+    public FluxCancelPathException() {}
+}

--- a/client/src/main/java/com/flipkart/flux/client/intercept/WorkflowInterceptor.java
+++ b/client/src/main/java/com/flipkart/flux/client/intercept/WorkflowInterceptor.java
@@ -34,6 +34,7 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Optional;
 
+import static com.flipkart.flux.client.constant.ClientConstants.CLIENT;
 import static com.flipkart.flux.client.constant.ClientConstants._VERSION;
 
 /**
@@ -45,7 +46,6 @@ import static com.flipkart.flux.client.constant.ClientConstants._VERSION;
 @Singleton
 public class WorkflowInterceptor implements MethodInterceptor {
 
-    public static final String CLIENT = "client";
     @Inject
     private LocalContext localContext;
     @Inject

--- a/client/src/main/java/com/flipkart/flux/client/runtime/FluxRuntimeConnector.java
+++ b/client/src/main/java/com/flipkart/flux/client/runtime/FluxRuntimeConnector.java
@@ -52,6 +52,13 @@ public interface FluxRuntimeConnector {
     void submitScheduledEvent(String name, Object data, String correlationId, String eventSource, Long scheduledTime);
 
     /**
+     * Cancels the event, which results cancellation of subsequent path in state machine DAG
+     * @param eventName name of the event which needs to be cancelled
+     * @param correlationId state machine identifier
+     */
+    void cancelEvent(String eventName, String correlationId);
+
+    /**
      * Updates the status of the Task identified by the specified Task ID 
      * @param executionUpdateData the execution update data
      */

--- a/client/src/main/java/com/flipkart/flux/client/runtime/FluxRuntimeConnectorHttpImpl.java
+++ b/client/src/main/java/com/flipkart/flux/client/runtime/FluxRuntimeConnectorHttpImpl.java
@@ -149,7 +149,20 @@ public class FluxRuntimeConnectorHttpImpl implements FluxRuntimeConnector {
         }
     }
 
-	/**
+    @Override
+    public void cancelEvent(String eventName, String correlationId) {
+        CloseableHttpResponse httpResponse = null;
+        try {
+            final EventData eventData = new EventData(eventName, null, null, null, true);
+            httpResponse = postOverHttp(eventData, "/" + correlationId + "/context/events?searchField=correlationId");
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        } finally {
+            HttpClientUtils.closeQuietly(httpResponse);
+        }
+    }
+
+    /**
 	 * Interface method implementation. Updates the status in persistence store by invoking suitable Flux runtime API
 	 * @see com.flipkart.flux.client.runtime.FluxRuntimeConnector#updateExecutionStatus(ExecutionUpdateData)
 	 */

--- a/client/src/test/java/com/flipkart/flux/client/intercept/SimpleWorkflowForTest.java
+++ b/client/src/test/java/com/flipkart/flux/client/intercept/SimpleWorkflowForTest.java
@@ -27,6 +27,7 @@ import javax.inject.Singleton;
 import java.lang.reflect.Method;
 import java.util.*;
 
+import static com.flipkart.flux.client.constant.ClientConstants.CLIENT;
 import static com.flipkart.flux.client.constant.ClientConstants._VERSION;
 
 /**
@@ -153,8 +154,8 @@ public class SimpleWorkflowForTest {
 
         final ObjectMapper objectMapper = new ObjectMapper();
         Set<EventData> expectedEventData = new HashSet<EventData>() {{
-            add(new EventData(STRING_EVENT_NAME+"0","com.flipkart.flux.client.intercept.SimpleWorkflowForTest$StringEvent",objectMapper.writeValueAsString(stringEvent),WorkflowInterceptor.CLIENT));
-            add(new EventData(INTEGER_EVENT_NAME+"1","com.flipkart.flux.client.intercept.SimpleWorkflowForTest$IntegerEvent",objectMapper.writeValueAsString(integerEvent),WorkflowInterceptor.CLIENT));
+            add(new EventData(STRING_EVENT_NAME+"0","com.flipkart.flux.client.intercept.SimpleWorkflowForTest$StringEvent",objectMapper.writeValueAsString(stringEvent),CLIENT));
+            add(new EventData(INTEGER_EVENT_NAME+"1","com.flipkart.flux.client.intercept.SimpleWorkflowForTest$IntegerEvent",objectMapper.writeValueAsString(integerEvent),CLIENT));
         }};
         return new StateMachineDefinition("",new MethodId(SimpleWorkflowForTest.class.getDeclaredMethod("simpleDummyWorkflow", StringEvent.class, IntegerEvent.class)).toString()+"_version1",1l,expectedStateDefs, expectedEventData, null);
 

--- a/client/src/test/java/com/flipkart/flux/client/intercept/TaskInterceptorTest.java
+++ b/client/src/test/java/com/flipkart/flux/client/intercept/TaskInterceptorTest.java
@@ -14,6 +14,7 @@
 
 package com.flipkart.flux.client.intercept;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.flipkart.flux.api.EventDefinition;
 import com.flipkart.flux.client.intercept.SimpleWorkflowForTest.IntegerEvent;
 import com.flipkart.flux.client.intercept.SimpleWorkflowForTest.StringEvent;
@@ -31,6 +32,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.omg.CORBA.OBJ_ADAPTER;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.lang.reflect.Method;
@@ -56,10 +58,13 @@ public class TaskInterceptorTest {
     private SimpleWorkflowForTest simpleWorkflowForTest;
     private TaskInterceptor taskInterceptor;
 
+    private ObjectMapper objectMapper;
+
     @Before
     public void setUp() throws Exception {
 //        localContext = Mockito.spy(new LocalContext());
-        taskInterceptor = new TaskInterceptor(localContext,executableRegistry);
+        objectMapper = new ObjectMapper();
+        taskInterceptor = new TaskInterceptor(localContext,executableRegistry, () -> objectMapper);
         simpleWorkflowForTest = new SimpleWorkflowForTest();
         when(localContext.isWorkflowInterception()).thenReturn(true);
     }

--- a/client/src/test/java/com/flipkart/flux/client/intercept/WorkflowInterceptorTest.java
+++ b/client/src/test/java/com/flipkart/flux/client/intercept/WorkflowInterceptorTest.java
@@ -35,6 +35,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import java.lang.reflect.Method;
 import java.util.Collection;
 
+import static com.flipkart.flux.client.constant.ClientConstants.CLIENT;
 import static com.flipkart.flux.client.constant.ClientConstants._VERSION;
 import static com.flipkart.flux.client.utils.TestUtil.dummyInvocation;
 import static org.mockito.Matchers.any;
@@ -108,8 +109,8 @@ public class WorkflowInterceptorTest {
         workflowInterceptor.invoke(dummyInvocation(invokedMethod,new Object[]{testStringEvent,testIntegerEvent}));
         /* verifications */
         verify(localContext,times(1)).addEvents(
-            new EventData(SimpleWorkflowForTest.STRING_EVENT_NAME + "0", StringEvent.class.getName(), objectMapper.writeValueAsString(testStringEvent), WorkflowInterceptor.CLIENT),
-            new EventData(SimpleWorkflowForTest.INTEGER_EVENT_NAME + "1", IntegerEvent.class.getName(), objectMapper.writeValueAsString(testIntegerEvent), WorkflowInterceptor.CLIENT)
+            new EventData(SimpleWorkflowForTest.STRING_EVENT_NAME + "0", StringEvent.class.getName(), objectMapper.writeValueAsString(testStringEvent), CLIENT),
+            new EventData(SimpleWorkflowForTest.INTEGER_EVENT_NAME + "1", IntegerEvent.class.getName(), objectMapper.writeValueAsString(testIntegerEvent), CLIENT)
         );
     }
 
@@ -146,8 +147,8 @@ public class WorkflowInterceptorTest {
         final MethodInvocation invocation = dummyInvocation(SimpleWorkflowForTest.class.getDeclaredMethod("simpleDummyWorkflow", StringEvent[].class), new Object[]{new StringEvent[]{wfParam1,wfParam2}});
         workflowInterceptor.invoke(invocation);
         verify(localContext,times(1)).registerNew(new MethodId(invocation.getMethod()).toString()+_VERSION+"1", 1l, "",null);
-        final EventData expectedData1 = new EventData("someName" /*cuz were using mock localContext */, "com.flipkart.flux.client.intercept.SimpleWorkflowForTest$StringEvent", objectMapper.writeValueAsString(wfParam1), WorkflowInterceptor.CLIENT);
-        final EventData expectedData2 = new EventData("someName", "com.flipkart.flux.client.intercept.SimpleWorkflowForTest$StringEvent", objectMapper.writeValueAsString(wfParam2), WorkflowInterceptor.CLIENT);
+        final EventData expectedData1 = new EventData("someName" /*cuz were using mock localContext */, "com.flipkart.flux.client.intercept.SimpleWorkflowForTest$StringEvent", objectMapper.writeValueAsString(wfParam1), CLIENT);
+        final EventData expectedData2 = new EventData("someName", "com.flipkart.flux.client.intercept.SimpleWorkflowForTest$StringEvent", objectMapper.writeValueAsString(wfParam2), CLIENT);
         verify(localContext,times(1)).addEvents(expectedData1,expectedData2);
     }
 }

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>com.flipkart</groupId>
         <artifactId>flux</artifactId>
-        <version>1.1.3-SNAPSHOT</version>
+        <version>1.1.4-SNAPSHOT</version>
     </parent>
 
     <groupId>com.flipkart.flux</groupId>
     <artifactId>common</artifactId>
-    <version>1.1.3-SNAPSHOT</version>
+    <version>1.1.4-SNAPSHOT</version>
     <name>common</name>
     <url>http://maven.apache.org</url>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>com.flipkart</groupId>
         <artifactId>flux</artifactId>
-        <version>1.1.3-SNAPSHOT</version>
+        <version>1.1.4-SNAPSHOT</version>
     </parent>
     
     <groupId>com.flipkart.flux</groupId>
     <artifactId>examples</artifactId>
-    <version>1.1.3-SNAPSHOT</version>
+    <version>1.1.4-SNAPSHOT</version>
     <name>examples</name>
     <url>http://maven.apache.org</url>
 

--- a/examples/src/main/java/com/flipkart/flux/examples/cancelpath/CancelPathWorkflow.java
+++ b/examples/src/main/java/com/flipkart/flux/examples/cancelpath/CancelPathWorkflow.java
@@ -39,21 +39,31 @@ public class CancelPathWorkflow {
 
     @Task(version = 1, retries = 0, timeout = 1000L)
     public ParamEvent task1() {
-        return new ParamEvent("task2");
+        return new ParamEvent("task1");
     }
 
     @Task(version = 1, retries = 0, timeout = 1000L)
     public ParamEvent task2(ParamEvent event) {
-        throw new FluxCancelPathException();
+        // logic which decides whether to cancel the path
+        if(event.data.length() == 5) {
+            throw new FluxCancelPathException();
+        }
+        return new ParamEvent(event.data + "_task2");
     }
 
     @Task(version = 1, retries = 0, timeout = 1000L)
     public ParamEvent task3(ParamEvent event) {
+        // logic which decides whether to cancel the path
+        if(event.data.length() < 5) {
+            throw new FluxCancelPathException();
+        }
         return new ParamEvent(event.data + "_task3");
     }
 
     @Task(version = 1, retries = 0, timeout = 1000L)
     public ParamEvent task4(ParamEvent event, ParamEvent event1) {
+        // This task is dependant on output of task2 and task3. But only one of the paths is executed, and other gets cancelled due to the above if conditions
+        // The event from cancelled path would be null, so do a null check
         return new ParamEvent((event != null ? event.data : "") + (event1 != null ? event1.data : "") + "_task4");
     }
 

--- a/examples/src/main/java/com/flipkart/flux/examples/cancelpath/CancelPathWorkflow.java
+++ b/examples/src/main/java/com/flipkart/flux/examples/cancelpath/CancelPathWorkflow.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2012-2016, the original author or authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.flipkart.flux.examples.cancelpath;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.flipkart.flux.client.exception.FluxCancelPathException;
+import com.flipkart.flux.client.model.*;
+
+/**
+ * This class shows how to use {@link FluxCancelPathException} to cancel a path in state machine.
+ * Created by shyam.akirala on 29/08/17.
+ */
+public class CancelPathWorkflow {
+
+    @Workflow(version = 1)
+    public void create(StartEvent startEvent) {
+        ParamEvent paramEvent1 = task1();
+        ParamEvent paramEvent2 = task2(paramEvent1);
+        ParamEvent paramEvent3 = task3(paramEvent1);
+        ParamEvent paramEvent4 = task4(paramEvent2, paramEvent3);
+        ParamEvent paramEvent5 = task5(paramEvent2);
+        ParamEvent paramEvent6 = task6(paramEvent5);
+        ParamEvent paramEvent7 = task7(paramEvent5);
+        ParamEvent paramEvent8 = task8(paramEvent5);
+        ParamEvent paramEvent9 = task9(paramEvent6, paramEvent7, paramEvent8);
+        task10(paramEvent4, paramEvent9);
+    }
+
+    @Task(version = 1, retries = 0, timeout = 1000L)
+    public ParamEvent task1() {
+        return new ParamEvent("task2");
+    }
+
+    @Task(version = 1, retries = 0, timeout = 1000L)
+    public ParamEvent task2(ParamEvent event) {
+        throw new FluxCancelPathException();
+    }
+
+    @Task(version = 1, retries = 0, timeout = 1000L)
+    public ParamEvent task3(ParamEvent event) {
+        return new ParamEvent(event.data + "_task3");
+    }
+
+    @Task(version = 1, retries = 0, timeout = 1000L)
+    public ParamEvent task4(ParamEvent event, ParamEvent event1) {
+        return new ParamEvent((event != null ? event.data : "") + (event1 != null ? event1.data : "") + "_task4");
+    }
+
+    @Task(version = 1, retries = 0, timeout = 1000L)
+    public ParamEvent task5(ParamEvent event) {
+        return new ParamEvent(event.data + "_task5");
+    }
+
+    @Task(version = 1, retries = 0, timeout = 1000L)
+    public ParamEvent task6(ParamEvent event) {
+        return new ParamEvent(event.data + "_task6");
+    }
+
+    @Task(version = 1, retries = 0, timeout = 1000L)
+    public ParamEvent task7(ParamEvent event) {
+        return new ParamEvent(event.data + "_task7");
+    }
+
+    @Task(version = 1, retries = 0, timeout = 1000L)
+    public ParamEvent task8(ParamEvent event) {
+        return new ParamEvent(event.data + "_task8");
+    }
+
+    @Task(version = 1, retries = 0, timeout = 1000L)
+    public ParamEvent task9(ParamEvent event, ParamEvent event1, ParamEvent event2) {
+        return new ParamEvent(event.data + "_" + event1.data + "_" + event2.data + "_task9");
+    }
+
+    @Task(version = 1, retries = 0, timeout = 1000L)
+    public void task10(ParamEvent event, ParamEvent event1) {
+        System.out.println("Executing task10. Event data " + (event != null ? event.data : "") + " " + (event1 != null ? event1.data : ""));
+    }
+}
+
+class ParamEvent implements Event {
+
+    @JsonProperty
+    String data;
+
+    public ParamEvent() {
+    }
+
+    public ParamEvent(String data) {
+        this.data = data;
+    }
+}
+
+class StartEvent implements Event {
+
+    @CorrelationId @JsonProperty
+    String id;
+
+    public StartEvent() {
+    }
+
+    public StartEvent(String id) {
+        this.id = id;
+    }
+
+}

--- a/examples/src/main/java/com/flipkart/flux/examples/cancelpath/RunCancelPathWorkflow.java
+++ b/examples/src/main/java/com/flipkart/flux/examples/cancelpath/RunCancelPathWorkflow.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2012-2016, the original author or authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.flipkart.flux.examples.cancelpath;
+
+import com.flipkart.flux.client.FluxClientComponentModule;
+import com.flipkart.flux.client.FluxClientInterceptorModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+
+/**
+ * This class can be used to run and observe the <code>CancelPathWorkflow</code>
+ * This or a similar class like this is _not_ required to be present in your actual production jar
+ *
+ * Created by shyam.akirala on 30/08/17.
+ */
+public class RunCancelPathWorkflow {
+    public static void main(String[] args) {
+
+        /* Initialise _your_ module*/
+        final Injector injector = Guice.createInjector(new FluxClientComponentModule(), new FluxClientInterceptorModule());
+
+        /* Note that we are using guice aop for now, hence your workflow instances need to use guice */
+        CancelPathWorkflow cancelPathWorkflow = injector.getInstance(CancelPathWorkflow.class);
+
+        /* Lets invoke our workflow */
+        System.out.println("[Main] Starting workflow execution");
+        cancelPathWorkflow.create(new StartEvent("example_cancel_path_flow"));
+
+        /* Since we've initialised flux, the process will continue to run till you explicitly kill it */
+    }
+}

--- a/examples/src/main/resources/flux_config.yml
+++ b/examples/src/main/resources/flux_config.yml
@@ -8,4 +8,5 @@ workflowClasses: ["com.flipkart.flux.examples.decision.NotificationService",
                   "com.flipkart.flux.examples.externalevents.ManualSellerVerificationFlow",
                   "com.flipkart.flux.examples.externalevents.ManualSellerVerificationService",
                   "com.flipkart.flux.examples.externalevents.NotificationService",
-                  "com.flipkart.flux.examples.externalevents.SellerDataService"]
+                  "com.flipkart.flux.examples.externalevents.SellerDataService",
+                  "com.flipkart.flux.examples.cancelpath.CancelPathWorkflow"]

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>com.flipkart</groupId>
         <artifactId>flux</artifactId>
-        <version>1.1.3-SNAPSHOT</version>
+        <version>1.1.4-SNAPSHOT</version>
     </parent>
 
     <groupId>com.flipkart.flux</groupId>
     <artifactId>model</artifactId>
-    <version>1.1.3-SNAPSHOT</version>
+    <version>1.1.4-SNAPSHOT</version>
     <name>model</name>
     <url>http://maven.apache.org</url>
 

--- a/model/src/main/java/com/flipkart/flux/domain/Event.java
+++ b/model/src/main/java/com/flipkart/flux/domain/Event.java
@@ -65,7 +65,7 @@ public class Event implements Serializable {
 
     /** Enum of Event statuses*/
     public enum EventStatus {
-        pending,triggered;
+        pending, triggered, cancelled;
     }
 
     /** Constructors */

--- a/persistence-mysql/pom.xml
+++ b/persistence-mysql/pom.xml
@@ -9,12 +9,12 @@
     <parent>
         <groupId>com.flipkart</groupId>
         <artifactId>flux</artifactId>
-        <version>1.1.3-SNAPSHOT</version>
+        <version>1.1.4-SNAPSHOT</version>
     </parent>
 
     <groupId>com.flipkart.flux</groupId>
     <artifactId>persistence-mysql</artifactId>
-    <version>1.1.3-SNAPSHOT</version>
+    <version>1.1.4-SNAPSHOT</version>
     <name>persistence-mysql</name>
     <url>http://maven.apache.org</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     
     <groupId>com.flipkart</groupId>
     <artifactId>flux</artifactId>
-    <version>1.1.3-SNAPSHOT</version>
+    <version>1.1.4-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>flux</name>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>com.flipkart</groupId>
         <artifactId>flux</artifactId>
-        <version>1.1.3-SNAPSHOT</version>
+        <version>1.1.4-SNAPSHOT</version>
     </parent>
 
     <groupId>com.flipkart.flux</groupId>
     <artifactId>runtime</artifactId>
-    <version>1.1.3-SNAPSHOT</version>
+    <version>1.1.4-SNAPSHOT</version>
     <name>runtime</name>
     <url>http://maven.apache.org</url>
 

--- a/runtime/src/main/java/com/flipkart/flux/controller/WorkFlowExecutionController.java
+++ b/runtime/src/main/java/com/flipkart/flux/controller/WorkFlowExecutionController.java
@@ -14,7 +14,11 @@
 package com.flipkart.flux.controller;
 
 import akka.actor.ActorRef;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flipkart.flux.api.EventAndExecutionData;
 import com.flipkart.flux.api.EventData;
+import com.flipkart.flux.api.EventDefinition;
+import com.flipkart.flux.api.ExecutionUpdateData;
 import com.flipkart.flux.dao.iface.AuditDAO;
 import com.flipkart.flux.dao.iface.EventsDAO;
 import com.flipkart.flux.dao.iface.StateMachinesDAO;
@@ -34,6 +38,8 @@ import org.slf4j.MDC;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import javax.transaction.Transactional;
+import java.io.IOException;
 import java.util.*;
 
 import static com.flipkart.flux.Constants.STATE_MACHINE_ID;
@@ -68,10 +74,14 @@ public class WorkFlowExecutionController {
     /** Metrics client for keeping track of task metrics*/
     private MetricsClient metricsClient;
 
+    /** ObjectMapper instance to be used for all purposes in this class */
+    private ObjectMapper objectMapper;
+
     /** Constructor for this class */
     @Inject
     public WorkFlowExecutionController(EventsDAO eventsDAO, StateMachinesDAO stateMachinesDAO,
-                                       StatesDAO statesDAO, AuditDAO auditDAO, RouterRegistry routerRegistry, RedriverRegistry redriverRegistry, MetricsClient metricsClient) {
+                                       StatesDAO statesDAO, AuditDAO auditDAO, RouterRegistry routerRegistry,
+                                       RedriverRegistry redriverRegistry, MetricsClient metricsClient) {
         this.eventsDAO = eventsDAO;
         this.stateMachinesDAO = stateMachinesDAO;
         this.statesDAO = statesDAO;
@@ -79,6 +89,7 @@ public class WorkFlowExecutionController {
         this.routerRegistry = routerRegistry;
         this.redriverRegistry = redriverRegistry;
         this.metricsClient = metricsClient;
+        this.objectMapper = new ObjectMapper();
     }
 
     /**
@@ -91,11 +102,138 @@ public class WorkFlowExecutionController {
         //create context and dependency graph
         Context context = new RAMContext(System.currentTimeMillis(), null, stateMachine); //TODO: set context id, should we need it ?
 
-        final List<String> triggeredEvents = eventsDAO.findTriggeredEventsNamesBySMId(stateMachine.getId());
+        final List<String> triggeredEvents = eventsDAO.findTriggeredOrCancelledEventsNamesBySMId(stateMachine.getId());
         Set<State> initialStates = context.getInitialStates(new HashSet<>(triggeredEvents));
         executeStates(stateMachine, initialStates);
 
         return initialStates;
+    }
+
+    /**
+     * Updates task status and retrieves the states which are dependant on this event and starts the execution of eligible states (whose all dependencies are met).
+     * @param stateMachine
+     * @param eventAndExecutionData
+     */
+    public void updateTaskStatusAndPostEvent(StateMachine stateMachine, EventAndExecutionData eventAndExecutionData) {
+        Event event = updateTaskStatusAndPersistEvent(stateMachine, eventAndExecutionData);
+        processEvent(event, stateMachine);
+    }
+
+    /**
+     * Updates task status and persists the event in a single transaction. Keeping this method as protected so that guice can intercept it.
+     * @param stateMachine
+     * @param eventAndExecutionData
+     */
+    @Transactional
+    protected Event updateTaskStatusAndPersistEvent(StateMachine stateMachine, EventAndExecutionData eventAndExecutionData) {
+        updateTaskStatus(stateMachine.getId(), eventAndExecutionData.getExecutionUpdateData().getTaskId(), eventAndExecutionData.getExecutionUpdateData());
+        return persistEvent(stateMachine, eventAndExecutionData.getEventData());
+    }
+
+    /**
+     * Updates task status and cancels paths which are dependant on the current event. After the cancellation of path, executes the states which can be executed.
+     * @param stateMachine
+     * @param eventAndExecutionData
+     */
+    public void updateTaskStatusAndHandlePathCancellation(StateMachine stateMachine, EventAndExecutionData eventAndExecutionData) {
+        Set<State> executableStates = updateTaskStatusAndCancelPath(stateMachine, eventAndExecutionData);
+        executeStates(stateMachine, executableStates);
+    }
+
+    /**
+     * Updates task status and cancels paths which are dependant on the current event
+     * @param stateMachine
+     * @param eventAndExecutionData
+     * @return executable states after cancellation
+     */
+    @Transactional
+    protected Set<State> updateTaskStatusAndCancelPath(StateMachine stateMachine, EventAndExecutionData eventAndExecutionData) {
+        updateTaskStatus(stateMachine.getId(), eventAndExecutionData.getExecutionUpdateData().getTaskId(), eventAndExecutionData.getExecutionUpdateData());
+        return cancelPath(stateMachine, eventAndExecutionData.getEventData());
+    }
+
+    /**
+     * Cancels paths which are dependant on the current event, and returns set of states which can be executed after the cancellation.
+     * @param stateMachine
+     * @param eventData
+     * @return executable states after cancellation
+     */
+    @Transactional
+    protected Set<State> cancelPath(StateMachine stateMachine, EventData eventData) {
+        Set<State> executableStates = new HashSet<>();
+
+        //create context and dependency graph
+        Context context = new RAMContext(System.currentTimeMillis(), null, stateMachine);
+
+        // get all events of this state machine in map<eventName, eventStatus> with lock
+        Map<String, Event.EventStatus> eventStatusMap = eventsDAO.getAllEventsNameAndStatus(stateMachine.getId(), true);
+
+        // the events which need to marked as cancelled
+        Queue<String> cancelledEvents = new LinkedList<>();
+
+        // add the current event
+        cancelledEvents.add(eventData.getName());
+
+        // until the cancelled events is empty
+        while(!cancelledEvents.isEmpty()) {
+
+            // get event from queue
+            String eventName = cancelledEvents.poll();
+
+            // mark the event as cancelled in DB in local map
+            eventsDAO.markEventAsCancelled(stateMachine.getId(), eventName);
+            eventStatusMap.put(eventName, Event.EventStatus.cancelled);
+
+            // fetch all states which are dependant on the current event
+            final Set<State> dependantStates = context.getDependantStates(eventName);
+
+            // for each state
+            for(State state : dependantStates) {
+
+                // fetch all event names this state is dependant on
+                List<String> dependencies = state.getDependencies();
+
+                boolean allCancelled = true;
+                boolean allMet = true;
+                for(String dependency : dependencies) {
+                    if(eventStatusMap.get(dependency) != Event.EventStatus.cancelled) {
+                        allCancelled = false;
+                    }
+                    if(!(eventStatusMap.get(dependency) == Event.EventStatus.cancelled || eventStatusMap.get(dependency) == Event.EventStatus.triggered)) {
+                        allMet = false;
+                    }
+                }
+
+                // if all dependencies are in cancelled state, then add the output event of the state to cancelled events and mark state as cancelled
+                if(allCancelled) {
+                    statesDAO.updateStatus(state.getId(), stateMachine.getId(), Status.cancelled);
+                    auditDAO.create(new AuditRecord(stateMachine.getId(), state.getId(), state.getAttemptedNoOfRetries(), Status.cancelled, null, null));
+                    EventDefinition eventDefinition = null;
+                    if(state.getOutputEvent() != null) {
+                        try {
+                            eventDefinition = objectMapper.readValue(state.getOutputEvent(), EventDefinition.class);
+                        } catch (IOException ex) {
+                            throw new RuntimeException("Error occurred while deserializing task outputEvent for stateMachineInstanceId: " + stateMachine.getId() + " taskId: " + state.getId());
+                        }
+                        cancelledEvents.add(eventDefinition.getName());
+                    }
+                } else if(allMet) {
+                    // if all dependencies are in cancelled or triggered state, then execute the state
+                    executableStates.add(state);
+                }
+            }
+        }
+        return executableStates;
+    }
+
+    /**
+     * This is called when an event is received with cancelled status. This cancels the particular path in state machine DAG.
+     * @param stateMachine
+     * @param eventData
+     */
+    public void handlePathCancellation(StateMachine stateMachine, EventData eventData) {
+        Set<State> executableStates = cancelPath(stateMachine, eventData);
+        executeStates(stateMachine, executableStates);
     }
 
     /**
@@ -104,27 +242,83 @@ public class WorkFlowExecutionController {
      * @param stateMachine
      */
     public Set<State> postEvent(EventData eventData, StateMachine stateMachine) {
+        Event event = persistEvent(stateMachine, eventData);
+        return processEvent(event, stateMachine);
+    }
+
+    /**
+     * Persists Event data and changes event status
+     * @param stateMachine
+     * @param eventData
+     * @return
+     */
+    @Transactional
+    public Event persistEvent(StateMachine stateMachine, EventData eventData) {
         //update event's data and status
         Event event = eventsDAO.findBySMIdAndName(stateMachine.getId(), eventData.getName());
         if(event == null)
             throw new IllegalEventException("Event with stateMachineId: "+stateMachine.getId()+", event name: "+ eventData.getName()+" not found");
-        event.setStatus(Event.EventStatus.triggered);
+        event.setStatus(eventData.getCancelled() != null && eventData.getCancelled() ? Event.EventStatus.cancelled : Event.EventStatus.triggered);
         event.setEventData(eventData.getData());
         event.setEventSource(eventData.getEventSource());
         eventsDAO.updateEvent(event);
+        return event;
+    }
 
+    /**
+     * Checks and triggers the states which are dependant on the current event
+     * @param event
+     * @param stateMachine
+     * @return
+     */
+    public Set<State> processEvent(Event event, StateMachine stateMachine) {
         //create context and dependency graph
         Context context = new RAMContext(System.currentTimeMillis(), null, stateMachine); //TODO: set context id, should we need it ?
 
         //get the states whose dependencies are met
-        final Set<State> dependantStates = context.getDependantStates(eventData.getName());
-        logger.debug("These states {} depend on event {}", dependantStates, eventData.getName());
+        final Set<State> dependantStates = context.getDependantStates(event.getName());
+        logger.debug("These states {} depend on event {}", dependantStates, event.getName());
         Set<State> executableStates = getExecutableStates(dependantStates, stateMachine.getId());
-        logger.debug("These states {} are now unblocked after event {}", executableStates, eventData.getName());
+        logger.debug("These states {} are now unblocked after event {}", executableStates, event.getName());
         //start execution of the above states
         executeStates(stateMachine, executableStates, event);
 
         return executableStates;
+    }
+
+
+    public void updateTaskStatus(Long machineId, Long stateId, ExecutionUpdateData executionUpdateData) {
+        com.flipkart.flux.domain.Status updateStatus = null;
+        switch (executionUpdateData.getStatus()) {
+            case initialized:
+                updateStatus = com.flipkart.flux.domain.Status.initialized;
+                break;
+            case running:
+                updateStatus = com.flipkart.flux.domain.Status.running;
+                break;
+            case completed:
+                updateStatus = com.flipkart.flux.domain.Status.completed;
+                break;
+            case cancelled:
+                updateStatus = com.flipkart.flux.domain.Status.cancelled;
+                break;
+            case errored:
+                updateStatus = com.flipkart.flux.domain.Status.errored;
+                break;
+            case sidelined:
+                updateStatus = com.flipkart.flux.domain.Status.sidelined;
+                break;
+        }
+        metricsClient.markMeter(new StringBuilder().
+                append("stateMachine.").
+                append(executionUpdateData.getStateMachineName()).
+                append(".task.").
+                append(executionUpdateData.getTaskName()).
+                append(".status.").
+                append(updateStatus.name()).
+                toString());
+        updateExecutionStatus(machineId, stateId, updateStatus, executionUpdateData.getRetrycount(),
+                executionUpdateData.getCurrentRetryCount(), executionUpdateData.getErrorMessage(), executionUpdateData.isDeleteFromRedriver());
     }
 
     /**
@@ -264,7 +458,7 @@ public class WorkFlowExecutionController {
     private Set<State> getExecutableStates(Set<State> dependantStates, Long stateMachineInstanceId) {
         // TODO : states can get triggered twice if we receive all their dependent events at roughly the same time.
         Set<State> executableStates = new HashSet<>();
-        Set<String> receivedEvents = new HashSet<>(eventsDAO.findTriggeredEventsNamesBySMId(stateMachineInstanceId));
+        Set<String> receivedEvents = new HashSet<>(eventsDAO.findTriggeredOrCancelledEventsNamesBySMId(stateMachineInstanceId));
 
         // for each state
         // 1. get the dependencies (events)

--- a/runtime/src/main/java/com/flipkart/flux/controller/WorkFlowExecutionController.java
+++ b/runtime/src/main/java/com/flipkart/flux/controller/WorkFlowExecutionController.java
@@ -137,6 +137,8 @@ public class WorkFlowExecutionController {
      */
     public void updateTaskStatusAndHandlePathCancellation(StateMachine stateMachine, EventAndExecutionData eventAndExecutionData) {
         Set<State> executableStates = updateTaskStatusAndCancelPath(stateMachine, eventAndExecutionData);
+        logger.info("Path cancellation is done for state machine: {} event: {} which has come from task: {}",
+                stateMachine.getId(), eventAndExecutionData.getEventData().getName(), eventAndExecutionData.getExecutionUpdateData().getTaskId());
         executeStates(stateMachine, executableStates);
     }
 
@@ -233,6 +235,8 @@ public class WorkFlowExecutionController {
      */
     public void handlePathCancellation(StateMachine stateMachine, EventData eventData) {
         Set<State> executableStates = cancelPath(stateMachine, eventData);
+        logger.info("Path cancellation is done for state machine: {} event: {}",
+                stateMachine.getId(), eventData.getName());
         executeStates(stateMachine, executableStates);
     }
 

--- a/runtime/src/main/java/com/flipkart/flux/dao/iface/EventsDAO.java
+++ b/runtime/src/main/java/com/flipkart/flux/dao/iface/EventsDAO.java
@@ -17,6 +17,7 @@ import com.flipkart.flux.api.EventData;
 import com.flipkart.flux.domain.Event;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * <code>EventsDAO</code> interface provides methods to perform CR operations on {@link Event}
@@ -39,12 +40,18 @@ public interface EventsDAO {
     /** Retrieves Event by state machine instance id and event name */
     Event findBySMIdAndName(Long stateMachineInstanceId, String eventName);
 
-    /** Retrieves list of event names which are in triggered state and belongs to provided state machine */
-    public List<String> findTriggeredEventsNamesBySMId(Long stateMachineInstanceId);
+    /** Retrieves list of event names which are in triggered state or cancelled state and belongs to provided state machine */
+    List<String> findTriggeredOrCancelledEventsNamesBySMId(Long stateMachineInstanceId);
 
     /** Retrieves list of events which are in triggered state and belongs to provided state machine */
-    public List<Event> findTriggeredEventsBySMId(Long stateMachineInstanceId);
+    List<Event> findTriggeredEventsBySMId(Long stateMachineInstanceId);
 
     /** Retrieves list of events by their names and state machine id */
-    public List<EventData> findByEventNamesAndSMId(List<String> eventNames, Long stateMachineInstanceId);
+    List<EventData> findByEventNamesAndSMId(List<String> eventNames, Long stateMachineInstanceId);
+
+    /** Retrieves all the events names and statuses. Selects for update if forUpdate is true */
+    Map<String, Event.EventStatus> getAllEventsNameAndStatus(Long stateMachineInstanceId, boolean forUpdate);
+
+    /** Marks an event as cancelled */
+    void markEventAsCancelled(Long stateMachineInstanceId, String eventName);
 }

--- a/runtime/src/main/java/com/flipkart/flux/resource/FsmGraphEdge.java
+++ b/runtime/src/main/java/com/flipkart/flux/resource/FsmGraphEdge.java
@@ -16,6 +16,7 @@ package com.flipkart.flux.resource;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.sql.Timestamp;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -39,22 +40,26 @@ public class FsmGraphEdge {
     /*Gives event data details*/
     @JsonProperty
     private String eventData;
+    /* Event last updated at timestamp*/
+    @JsonProperty
+    private Timestamp updatedAt;
 
     /* For Jackson */
     FsmGraphEdge() {
-        this(null,null,null,null);
+        this(null,null,null,null,null);
     }
 
-    public FsmGraphEdge(String label, String status,String source,String eventData) {
-        this(new HashSet<>(),label,status,source,eventData);
+    public FsmGraphEdge(String label, String status, String source, String eventData, Timestamp updatedAt) {
+        this(new HashSet<>(),label,status,source,eventData,updatedAt);
     }
 
-    public FsmGraphEdge(Set<Long> incidentOn, String label, String status,String source,String eventData) {
+    public FsmGraphEdge(Set<Long> incidentOn, String label, String status,String source,String eventData, Timestamp updatedAt) {
         this.incidentOn = incidentOn;
         this.label = (label == null ? "" : label.trim());
         this.status = status;
         this.source = (source == null ? "" : source.trim());
         this.eventData = eventData;
+        this.updatedAt = updatedAt;
     }
 
     @JsonIgnore

--- a/runtime/src/main/java/com/flipkart/flux/resource/FsmGraphVertex.java
+++ b/runtime/src/main/java/com/flipkart/flux/resource/FsmGraphVertex.java
@@ -28,15 +28,19 @@ public class FsmGraphVertex {
     /* Label to show on the vertex */
     @JsonProperty
     private String label;
+    /* Task status*/
+    @JsonProperty
+    private String status;
 
     /* For Jackson */
     FsmGraphVertex() {
-        this(null,null);
+        this(null,null,null);
     }
 
-    public FsmGraphVertex(Long id, String label) {
+    public FsmGraphVertex(Long id, String label, String status) {
         this.id = id;
         this.label = (label == null ? "" : label.trim());
+        this.status = status;
     }
 
     public Long getId() {
@@ -51,19 +55,19 @@ public class FsmGraphVertex {
         FsmGraphVertex that = (FsmGraphVertex) o;
 
         if (!id.equals(that.id)) return false;
-        return label.equals(that.label);
-
+        return label.equals(that.label) && status.equals(that.status);
     }
 
     @Override
     public int hashCode() {
         int result = id.hashCode();
         result = 31 * result + label.hashCode();
+        result = 31 * result + status.hashCode();
         return result;
     }
 
     @Override
     public String toString() {
-        return id + ":" + label;
+        return id + ":" + label+ ":" + status;
     }
 }

--- a/runtime/src/main/resources/packaged/webapps/dashboard/WEB-INF/pages/fsmview.ftl
+++ b/runtime/src/main/resources/packaged/webapps/dashboard/WEB-INF/pages/fsmview.ftl
@@ -129,23 +129,39 @@
     <div id="event-details-modal" class="modal fade" role="dialog">
         <div class="modal-dialog">
             <!-- Modal content-->
-            <div class="modal-content">
+            <div class="modal-content" style="height: 570px;">
                 <div class="modal-header" >
                     <button type="button" class="close" data-dismiss="modal">&times;</button>
                     <h4 class="modal-title">Event Information</h4>
                 </div>
                 <div class="modal-body">
-                    <div class="form-group">
-                        <select style="height:28px;width:567px" class="selectpicker" id="event-data-select" ><#--all option will come here--></select>
-                    </div>
-                    <div id="event-data">
-                        <textarea readonly rows="15" cols="50" id="event-data-txt-box" style="height: 262px;width: 567px;max-height: 262px;overflow-y: auto;resize: none;" data-role="none"></textarea>
+                    <div class="container col-md-12">
+                        <div class="form-group">
+                            <select style="height:28px;width:550px" class="selectpicker" id="event-data-select" ><#--all option will come here--></select>
+                        </div>
+                        <div id="event-data">
+                            <textarea readonly rows="15" cols="50" id="event-data-txt-box" style="height: 262px;width: 550px;max-height: 262px;overflow-y: auto;resize: none;" data-role="none"></textarea>
+                        </div>
+                        <div>
+                            <div>
+                                <span style="text-align: left">Status:</span>
+                            </div>
+                            <div>
+                                <span style="text-align: left;" id="event-status-label"></span>
+                            </div>
+                            <br>
+                            <div>
+                                <span style="text-align: left">Updated At:</span>
+                            </div>
+                            <div>
+                                <span style="text-align: left" id="event-updated-at-label"></span>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
     </div>
-
 
     <script type="text/javascript">
 
@@ -300,8 +316,8 @@
             // Make the vertex nodes
             _.each(adjacencyList, function(edgeData,vertexIdentifier ) {
             	var stateColor = '#33ccff'; // default is 'initialized' color
-            	if (edgeData != null) {
-	            	switch(edgeData.status) {
+            	if (vertexIdentifier != null) {
+	            	switch(vertexIdentifier.split(":")[2]) {
 	            	case 'initialized':
 	            		stateColor = '#33ccff';
 	            		break;
@@ -480,20 +496,24 @@
             $('#event-data-select').append('<option value="" disabled selected value>--select Event--</option>');
             var count=0;
             for(var i=0;i<data.initStateEdges.length;i++){
-                eventNameDataMap[data.initStateEdges[i].label] = data.initStateEdges[i].eventData;
+                eventNameDataMap[data.initStateEdges[i].label] = {eventData: data.initStateEdges[i].eventData, status: data.initStateEdges[i].status, updatedAt: data.initStateEdges[i].updatedAt};
                 eventNames[count] = data.initStateEdges[i].label;
                 count++;
             }
             for(var stateIdentifier in data.fsmGraphData) {
                 if(data.fsmGraphData[stateIdentifier].label != "") {
-                    eventNameDataMap[data.fsmGraphData[stateIdentifier].label] = data.fsmGraphData[stateIdentifier].eventData;
+                    eventNameDataMap[data.fsmGraphData[stateIdentifier].label] = { eventData: data.fsmGraphData[stateIdentifier]["eventData"],
+                        status: data.fsmGraphData[stateIdentifier]["status"],
+                        updatedAt: data.fsmGraphData[stateIdentifier]["updatedAt"]};
                     eventNames[count] = data.fsmGraphData[stateIdentifier].label;
                     count++;
                 }
             }
             eventNames.sort();
             for(var i=0; i<eventNames.length; i++){
-                $('#event-data-select').append('<option>'+eventNames[i]+'</option>');
+                if(eventNames[i] != null && eventNames[i] != "") {
+                    $('#event-data-select').append('<option>' + eventNames[i] + '</option>');
+                }
             }
         }
 
@@ -520,7 +540,7 @@
         $('.modal').on('hidden.bs.modal', function() {
             $("#unsideline-msg").empty();
             $("#unsideline-button-submit-ok-toggle").empty();
-            $("#event-data-txt-box").empty();
+            clearEventInfoModalParams();
             document.getElementById("event-data-select").selectedIndex = 0;
             document.getElementById("errored-state-list").selectedIndex = 0;
             document.getElementById("errored-state-list").disabled = false;
@@ -531,12 +551,20 @@
             $("#unsideline-button-submit-ok-toggle").append('<button type="button" id="fsm-modal-unsideline" class="btn btn-sm btn-primary center-block" onclick="unSideline()" data-toogle="modal" >Submit</button>');
         }
 
+        function clearEventInfoModalParams() {
+            $("#event-data-txt-box").empty();
+            $("#event-status-label").empty();
+            $("#event-updated-at-label").empty();
+        }
+
         //function to get event data on select of event name
         $(function() {
             $('.selectpicker').on('change', function(){
-                $("#event-data-txt-box").empty();
+                clearEventInfoModalParams();
                 var selectedEventName = $(this).find("option:selected").val();
-                $("#event-data-txt-box").append(eventNameDataMap[selectedEventName]);
+                $("#event-data-txt-box").append(eventNameDataMap[selectedEventName].eventData);
+                $("#event-status-label").append(eventNameDataMap[selectedEventName].status);
+                $("#event-updated-at-label").append(getFormattedDate(new Date(eventNameDataMap[selectedEventName].updatedAt)));
             });
         });
 

--- a/runtime/src/test/java/com/flipkart/flux/controller/WorkFlowExecutionControllerTest.java
+++ b/runtime/src/test/java/com/flipkart/flux/controller/WorkFlowExecutionControllerTest.java
@@ -20,6 +20,7 @@ import akka.testkit.TestActorRef;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.flipkart.flux.MockActorRef;
 import com.flipkart.flux.api.EventData;
+import com.flipkart.flux.api.EventDefinition;
 import com.flipkart.flux.dao.iface.AuditDAO;
 import com.flipkart.flux.dao.iface.EventsDAO;
 import com.flipkart.flux.dao.iface.StateMachinesDAO;
@@ -40,9 +41,9 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import java.util.Arrays;
-import java.util.Collections;
+import java.util.*;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.*;
@@ -100,7 +101,7 @@ public class WorkFlowExecutionControllerTest {
         final EventData testEventData = new EventData("event0", "java.lang.String", "42", "runtime");
         when(eventsDAO.findBySMIdAndName(1l, "event0")).thenReturn(new Event("event0", "java.lang.String", Event.EventStatus.pending, 1l, null, null));
         EventData[] expectedEvents = new EventData[]{new EventData("event0","java.lang.String","42","runtime")};
-        when(eventsDAO.findTriggeredEventsNamesBySMId(1l)).thenReturn(Collections.singletonList("event0"));
+        when(eventsDAO.findTriggeredOrCancelledEventsNamesBySMId(1l)).thenReturn(Collections.singletonList("event0"));
         workFlowExecutionController.postEvent(testEventData, TestUtils.getStandardTestMachineWithId());
 
         verify(routerRegistry, times(1)).getRouter("com.flipkart.flux.dao.TestWorkflow_dummyTask"); // For 1 unblocked states
@@ -112,7 +113,7 @@ public class WorkFlowExecutionControllerTest {
     public void testEventPost_shouldNotFetchEventDataFromDBIfStateIsDependantOnSingleEvent() throws Exception {
         final EventData testEventData = new EventData("event1", "foo", "someStringData", "runtime");
         when(eventsDAO.findBySMIdAndName(1l, "event1")).thenReturn(new Event("event1", "foo", Event.EventStatus.pending, 1l, null, null));
-        when(eventsDAO.findTriggeredEventsNamesBySMId(1l)).thenReturn(Collections.singletonList("event1"));
+        when(eventsDAO.findTriggeredOrCancelledEventsNamesBySMId(1l)).thenReturn(Collections.singletonList("event1"));
         workFlowExecutionController.postEvent(testEventData, TestUtils.getStandardTestMachineWithId());
 
         // As states 2 and 3 dependant on single event there should be no more interactions with eventDAO to fetch event data
@@ -125,14 +126,14 @@ public class WorkFlowExecutionControllerTest {
         when(eventsDAO.findBySMIdAndName(1l, "event1")).thenReturn(new Event("event1", "java.lang.String", Event.EventStatus.pending, 1l, null, null));
         EventData[] expectedEvents1 = new EventData[]{new EventData("event1","java.lang.String","42","runtime")};
         when(eventsDAO.findByEventNamesAndSMId(Collections.singletonList("event1"),1l)).thenReturn(Arrays.asList(expectedEvents1));
-        when(eventsDAO.findTriggeredEventsNamesBySMId(1l)).thenReturn(Collections.singletonList("event1"));
+        when(eventsDAO.findTriggeredOrCancelledEventsNamesBySMId(1l)).thenReturn(Collections.singletonList("event1"));
         workFlowExecutionController.postEvent(testEventData1, TestUtils.getStandardTestMachineWithId());
 
         final EventData testEventData0 = new EventData("event0", "java.lang.String", "42", "runtime");
         when(eventsDAO.findBySMIdAndName(1l, "event0")).thenReturn(new Event("event0", "java.lang.String", Event.EventStatus.pending, 1l, null, null));
         EventData[] expectedEvents0 = new EventData[]{new EventData("event0","java.lang.String","42","runtime")};
         when(eventsDAO.findByEventNamesAndSMId(Collections.singletonList("event0"),1l)).thenReturn(Arrays.asList(expectedEvents0));
-        when(eventsDAO.findTriggeredEventsNamesBySMId(1l)).thenReturn(Collections.singletonList("event0"));
+        when(eventsDAO.findTriggeredOrCancelledEventsNamesBySMId(1l)).thenReturn(Collections.singletonList("event0"));
         workFlowExecutionController.postEvent(testEventData0, TestUtils.getStandardTestMachineWithId());
 
         // give time to execute
@@ -147,7 +148,7 @@ public class WorkFlowExecutionControllerTest {
         final EventData testEventData = new EventData("event0", "java.lang.String", "42", "runtime");
         when(eventsDAO.findBySMIdAndName(1l, "event0")).thenReturn(new Event("event0", "java.lang.String", Event.EventStatus.pending, 1l, null, null));
         EventData[] expectedEvents = new EventData[]{new EventData("event0","java.lang.String","42","runtime")};
-        when(eventsDAO.findTriggeredEventsNamesBySMId(1l)).thenReturn(Collections.singletonList("event0"));
+        when(eventsDAO.findTriggeredOrCancelledEventsNamesBySMId(1l)).thenReturn(Collections.singletonList("event0"));
         workFlowExecutionController.postEvent(testEventData, TestUtils.getStandardTestMachineWithId());
         StateMachine stateMachine = stateMachinesDAO.findById(1L);
         State state = stateMachine.getStates().stream().filter((s)->s.getId() == 4L).findFirst().orElse(null);
@@ -166,7 +167,7 @@ public class WorkFlowExecutionControllerTest {
         final EventData testEventData = new EventData("event0", "java.lang.String", "42", "runtime");
         when(eventsDAO.findBySMIdAndName(1l, "event0")).thenReturn(new Event("event0", "java.lang.String", Event.EventStatus.pending, 1l, null, null));
         EventData[] expectedEvents = new EventData[]{new EventData("event0","java.lang.String","42","runtime")};
-        when(eventsDAO.findTriggeredEventsNamesBySMId(1l)).thenReturn(Collections.singletonList("event0"));
+        when(eventsDAO.findTriggeredOrCancelledEventsNamesBySMId(1l)).thenReturn(Collections.singletonList("event0"));
         workFlowExecutionController.postEvent(testEventData, TestUtils.getStandardTestMachineWithId());
         StateMachine stateMachine = stateMachinesDAO.findById(1L);
         State state = stateMachine.getStates().stream().filter((s)->s.getId() == 4L).findFirst().orElse(null);
@@ -185,7 +186,7 @@ public class WorkFlowExecutionControllerTest {
         final EventData testEventData = new EventData("event0", "java.lang.String", "42", "runtime");
         when(eventsDAO.findBySMIdAndName(1l, "event0")).thenReturn(new Event("event0", "java.lang.String", Event.EventStatus.pending, 1l, null, null));
         EventData[] expectedEvents = new EventData[]{new EventData("event0","java.lang.String","42","runtime")};
-        when(eventsDAO.findTriggeredEventsNamesBySMId(1l)).thenReturn(Collections.singletonList("event0"));
+        when(eventsDAO.findTriggeredOrCancelledEventsNamesBySMId(1l)).thenReturn(Collections.singletonList("event0"));
         workFlowExecutionController.postEvent(testEventData, TestUtils.getStandardTestMachineWithId());
         StateMachine stateMachine = stateMachinesDAO.findById(1L);
         State state = stateMachine.getStates().stream().filter((s)->s.getId() == 4L).findFirst().orElse(null);
@@ -197,5 +198,81 @@ public class WorkFlowExecutionControllerTest {
         verify(routerRegistry, times(1)).getRouter("com.flipkart.flux.dao.TestWorkflow_dummyTask"); // the router should receive only one execution request
         mockActor.underlyingActor().assertMessageReceived(new TaskAndEvents("dummyTask", "com.flipkart.flux.dao.TestWorkflow_dummyTask_java.lang.Integer_java.lang.String_version1", 4L, expectedEvents, 1l, "test_state_machine", TestUtils.toStr(TestUtils.getOutputEvent("event3", Integer.class)),2), 1);
         verifyNoMoreInteractions(routerRegistry);
+    }
+
+    @Test
+    public void testCancelPath_shouldCancelPathTillJoinNode() throws Exception {
+
+        //setup the below state machine, and do cancel with event3, that should cancel till state3
+        //
+        //   state1 --------(event1)---------> state2 --------(event2)--------------------> state3
+        //    |                                                                               ^
+        //    |                                                                               |
+        //    |                           ---(event3)--> state5 --(event4)---              (event6)
+        //    |                          |                                   |                |
+        //    |----(event1)---> state4 --                                    |---> state7 ----
+        //                               |---(event3)--> state6 --(event5)---|
+        //
+        HashMap<String, Event.EventStatus> eventStatusHashMap = new HashMap<String, Event.EventStatus>() {{
+            put("event1", Event.EventStatus.triggered);
+            put("event2", Event.EventStatus.triggered);
+            put("event3", Event.EventStatus.pending);
+            put("event4", Event.EventStatus.pending);
+            put("event5", Event.EventStatus.pending);
+        }};
+
+        String outputEvent1 = null;
+        String outputEvent2 = null;
+        String outputEvent3 = null;
+        String outputEvent4 = null;
+        String outputEvent5 = null;
+        String outputEvent6 = null;
+        try {
+            outputEvent1 = objectMapper.writeValueAsString(new EventDefinition("event1", "SomeEvent.class"));
+            outputEvent2 = objectMapper.writeValueAsString(new EventDefinition("event2", "SomeEvent.class"));
+            outputEvent3 = objectMapper.writeValueAsString(new EventDefinition("event3", "SomeEvent.class"));
+            outputEvent4 = objectMapper.writeValueAsString(new EventDefinition("event4", "SomeEvent.class"));
+            outputEvent5 = objectMapper.writeValueAsString(new EventDefinition("event5", "SomeEvent.class"));
+            outputEvent6 = objectMapper.writeValueAsString(new EventDefinition("event6", "SomeEvent.class"));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        State state1 = new State(1L, "state1", null, null, null, null, new ArrayList<>(), 0L, 1000L, outputEvent1, Status.initialized, null, 0L);
+        TestUtils.setProperty(state1, "id", 1L); state1.setStateMachineId(1L);
+        State state2 = new State(1L, "state2", null, null, null, null, new ArrayList<String>(){{add("event1");}}, 0L, 1000L, outputEvent2, Status.initialized, null, 0L);
+        TestUtils.setProperty(state2, "id", 2L); state2.setStateMachineId(1L);
+        State state3 = new State(1L, "state3", null, null, null, null, new ArrayList<String>(){{add("event2");add("event6");}}, 0L, 1000L, null, Status.initialized, null, 0L);
+        TestUtils.setProperty(state3, "id", 3L); state3.setStateMachineId(1L);
+        State state4 = new State(1L, "state4", null, null, null, null, new ArrayList<String>(){{add("event1");}}, 0L, 1000L, outputEvent3, Status.initialized, null, 0L);
+        TestUtils.setProperty(state4, "id", 4L); state4.setStateMachineId(1L);
+        State state5 = new State(1L, "state5", null, null, null, null, new ArrayList<String>(){{add("event3");}}, 0L, 1000L, outputEvent4, Status.initialized, null, 0L);
+        TestUtils.setProperty(state5, "id", 5L); state5.setStateMachineId(1L);
+        State state6 = new State(1L, "state6", null, null, null, null, new ArrayList<String>(){{add("event3");}}, 0L, 1000L, outputEvent5, Status.initialized, null, 0L);
+        TestUtils.setProperty(state6, "id", 6L); state6.setStateMachineId(1L);
+        State state7 = new State(1L, "state7", null, null, null, null, new ArrayList<String>(){{add("event4");add("event5");}}, 0L, 1000L, outputEvent6, Status.initialized, null, 0L);
+        TestUtils.setProperty(state7, "id", 7L); state7.setStateMachineId(1L);
+
+        Set<State> states = new HashSet<State>(){{add(state1);add(state2);add(state3);add(state4);add(state5);add(state6);add(state7);}};
+        StateMachine stateMachine = new StateMachine(1L, "state_machine_1", null, states, "magic_number_1");
+        TestUtils.setProperty(stateMachine, "id", 1L);
+        EventData testEventData = new EventData("event3", null, null, "runtime", true);
+        when(eventsDAO.getAllEventsNameAndStatus(1L, true)).thenReturn(eventStatusHashMap);
+
+        // invoke cancel
+        Set<State> executableStates = workFlowExecutionController.cancelPath(stateMachine, testEventData);
+
+        assertThat(executableStates.size()).isEqualTo(1);
+        assertThat(executableStates.contains("state3"));
+        verify(eventsDAO).markEventAsCancelled(1L, "event3");
+        verify(eventsDAO).markEventAsCancelled(1L, "event4");
+        verify(eventsDAO).markEventAsCancelled(1L, "event5");
+        verify(eventsDAO).markEventAsCancelled(1L, "event6");
+
+        verify(statesDAO).updateStatus(5L, 1L, Status.cancelled);
+        verify(statesDAO).updateStatus(6L, 1L, Status.cancelled);
+        verify(statesDAO).updateStatus(7L, 1L, Status.cancelled);
+
+
     }
 }

--- a/runtime/src/test/java/com/flipkart/flux/integration/E2ETest.java
+++ b/runtime/src/test/java/com/flipkart/flux/integration/E2ETest.java
@@ -85,7 +85,7 @@ public class E2ETest {
         assertThat(eventsDAO.findBySMInstanceId(smId)).hasSize(3);
 
         /** All the events should be in triggered state after execution*/
-        assertThat(eventsDAO.findTriggeredEventsNamesBySMId(smId)).hasSize(3);
+        assertThat(eventsDAO.findTriggeredOrCancelledEventsNamesBySMId(smId)).hasSize(3);
     }
 
     @Test

--- a/runtime/src/test/java/com/flipkart/flux/resource/StateMachineResourceTest.java
+++ b/runtime/src/test/java/com/flipkart/flux/resource/StateMachineResourceTest.java
@@ -220,10 +220,6 @@ public class StateMachineResourceTest {
 
         String eventJson = IOUtils.toString(this.getClass().getClassLoader().getResourceAsStream("event_data.json"));
 
-        //request with searchField param missing
-        final HttpResponse<String> eventPostResponse = Unirest.post(STATE_MACHINE_RESOURCE_URL+SLASH+"magic_number_1"+"/context/events?triggerTime=123").header("Content-Type","application/json").body(eventJson).asString();
-        assertThat(eventPostResponse.getStatus()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
-
         //request with searchField param having value other than correlationId
         final HttpResponse<String> eventPostResponseWithWrongTag = Unirest.post(STATE_MACHINE_RESOURCE_URL+SLASH+"magic_number_1"+"/context/events?searchField=dummy&triggerTime=123").header("Content-Type","application/json").body(eventJson).asString();
         assertThat(eventPostResponseWithWrongTag.getStatus()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
@@ -242,10 +238,9 @@ public class StateMachineResourceTest {
         String eventJson = IOUtils.toString(this.getClass().getClassLoader().getResourceAsStream("event_data.json"));
         Unirest.post(STATE_MACHINE_RESOURCE_URL+SLASH+"magic_number_1"+"/context/events?searchField=correlationId&triggerTime="+triggerTime)
                 .header("Content-Type", "application/json").body(eventJson).asString();
-        Thread.sleep(500);
 
         //verify event has been saved in DB
-        assertThat(eventSchedulerDao.retrieveOldest(1).get(0)).isEqualTo(new ScheduledEvent("magic_number_1", "event0", triggerTime, "{\"name\":\"event0\",\"type\":\"java.lang.String\",\"data\":\"42\",\"eventSource\":null}"));
+        assertThat(eventSchedulerDao.retrieveOldest(1).get(0)).isEqualTo(new ScheduledEvent("magic_number_1", "event0", triggerTime, "{\"name\":\"event0\",\"type\":\"java.lang.String\",\"data\":\"42\",\"eventSource\":null,\"cancelled\":null}"));
 
         //waiting for 7 seconds here, to match Event scheduler thread's initial delay of 10 sec (some boot up time + 7 seconds will surpass 10 sec)
         Thread.sleep(7000);

--- a/runtime/src/test/java/com/flipkart/flux/util/TestUtils.java
+++ b/runtime/src/test/java/com/flipkart/flux/util/TestUtils.java
@@ -76,7 +76,7 @@ public class TestUtils {
     }
 
     /** Sets an object property using reflection*/
-    private static boolean setProperty(Object object, String fieldName, Object fieldValue) {
+    public static boolean setProperty(Object object, String fieldName, Object fieldValue) {
         Class<?> clazz = object.getClass();
         while (clazz != null) {
             Field field = null;

--- a/scheduler/pom.xml
+++ b/scheduler/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>com.flipkart</groupId>
         <artifactId>flux</artifactId>
-        <version>1.1.3-SNAPSHOT</version>
+        <version>1.1.4-SNAPSHOT</version>
     </parent>
 
     <groupId>com.flipkart.flux</groupId>
     <artifactId>scheduler</artifactId>
-    <version>1.1.3-SNAPSHOT</version>
+    <version>1.1.4-SNAPSHOT</version>
     <name>scheduler</name>
     <url>http://maven.apache.org</url>
 

--- a/task/pom.xml
+++ b/task/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>com.flipkart</groupId>
         <artifactId>flux</artifactId>
-        <version>1.1.3-SNAPSHOT</version>
+        <version>1.1.4-SNAPSHOT</version>
     </parent>
 
     <groupId>com.flipkart.flux</groupId>
     <artifactId>task</artifactId>
-    <version>1.1.3-SNAPSHOT</version>
+    <version>1.1.4-SNAPSHOT</version>
     <name>task</name>
     <url>http://maven.apache.org</url>
 

--- a/task/src/main/java/com/flipkart/flux/impl/boot/ActorSystemManager.java
+++ b/task/src/main/java/com/flipkart/flux/impl/boot/ActorSystemManager.java
@@ -30,6 +30,7 @@ import scala.concurrent.duration.Duration;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
+import java.io.File;
 
 /**
  * Responsible for bringing up the entire akka runtime
@@ -82,7 +83,16 @@ public class ActorSystemManager implements Initializable {
         if(withMetrics) {
             Kamon.start();
         }
-        Config config = ConfigFactory.load(configName);
+
+        Config config;
+        // check if actor system config file has been passed as part of system parameters
+        String fluxActorsystemConfigurationFile = System.getProperty("flux.actorsystemConfigurationFile");
+        if(fluxActorsystemConfigurationFile != null) {
+            config = ConfigFactory.parseFile(new File(fluxActorsystemConfigurationFile));
+        } else {
+            config = ConfigFactory.load(configName);
+        }
+
         system = ActorSystem.create(actorSystemName, config);
         // register the Dead Letter Actor
         final ActorRef deadLetterActor = system.actorOf(Props.create(DeadLetterActor.class));

--- a/task/src/main/java/com/flipkart/flux/impl/task/AkkaTask.java
+++ b/task/src/main/java/com/flipkart/flux/impl/task/AkkaTask.java
@@ -144,7 +144,7 @@ public class AkkaTask extends UntypedActor {
                         if (outputEvent != null) {
                             // after successful task execution, post the generated output event for further processing, also update status as part of same call
                             fluxRuntimeConnector.submitEventAndUpdateStatus(
-                                    new EventData(outputEvent.getName(), outputEvent.getType(), outputEvent.getEventData(), outputEvent.getEventSource()),
+                                    new EventData(outputEvent.getName(), outputEvent.getType(), outputEvent.getEventData(), outputEvent.getEventSource(), outputEvent.getStatus() == Event.EventStatus.cancelled),
                                     outputEvent.getStateMachineInstanceId(),
                                     new ExecutionUpdateData(taskAndEvent.getStateMachineId(), taskAndEvent.getStateMachineName(), taskAndEvent.getTaskName() ,taskAndEvent.getTaskId(), Status.completed, taskAndEvent.getRetryCount(),
                                             taskAndEvent.getCurrentRetryCount(), null, true));

--- a/task/src/main/java/com/flipkart/flux/impl/task/LocalJvmTask.java
+++ b/task/src/main/java/com/flipkart/flux/impl/task/LocalJvmTask.java
@@ -70,13 +70,15 @@ public class LocalJvmTask extends AbstractTask {
             Class objectMapper = objectMapperInstance.getClass();
 
 			for (int i = 0; i < parameterTypes.length; i++) {
-				if (parameterTypes[i].isAssignableFrom(Class.forName(events[i].getType(), true, classLoader))) {
-					parameters[i] = objectMapper.getMethod("readValue", String.class, Class.class).invoke(objectMapperInstance, events[i].getData(),Class.forName(events[i].getType(), true, classLoader));
-				} else {
-					logger.warn("Parameter type {} did not match with event: {}", parameterTypes[i], events[i]);
-					throw new RuntimeException(
-							"Parameter type " + parameterTypes[i] + " did not match with event: " + events[i]);
-				}
+			    if(events[i].getData() != null) {
+                    if (parameterTypes[i].isAssignableFrom(Class.forName(events[i].getType(), true, classLoader))) {
+                        parameters[i] = objectMapper.getMethod("readValue", String.class, Class.class).invoke(objectMapperInstance, events[i].getData(), Class.forName(events[i].getType(), true, classLoader));
+                    } else {
+                        logger.warn("Parameter type {} did not match with event: {}", parameterTypes[i], events[i]);
+                        throw new RuntimeException(
+                                "Parameter type " + parameterTypes[i] + " did not match with event: " + events[i]);
+                    }
+                }
 			}
 
             Method writeValueAsString = objectMapper.getMethod("writeValueAsString", Object.class);


### PR DESCRIPTION
Dynamic conditions are supported using path cancellation. Whenever the user decides he doesn't need to process the particular path he has to throw FluxCancelPathException. If flux sees this exception anywhere in the stack trace, it will cancel the subsequent tasks, until a join task with real event occurs. 