### PR TITLE
Modified response code for ConstraintViolation

### DIFF
--- a/runtime/src/main/java/com/flipkart/flux/resource/StateMachineResource.java
+++ b/runtime/src/main/java/com/flipkart/flux/resource/StateMachineResource.java
@@ -138,7 +138,7 @@ public class StateMachineResource {
         if (stateMachineDefinition == null)
             throw new IllegalRepresentationException("State machine definition is empty");
 
-        StateMachine stateMachine = null, stateMachine1 = null;
+        StateMachine stateMachine = null;
 
 
         final String stateMachineInstanceId;

--- a/runtime/src/main/java/com/flipkart/flux/resource/StateMachineResource.java
+++ b/runtime/src/main/java/com/flipkart/flux/resource/StateMachineResource.java
@@ -160,14 +160,13 @@ public class StateMachineResource {
                     append(".started").toString());
         } catch (ConstraintViolationException ex) {
             //In case of Duplicate correlation key, return http code 409 conflict
-            stateMachine1 = stateMachinesDAO.findById(stateMachineInstanceId);
-            if (stateMachine1 != null) {
+            if (ex.getCause().getMessage().contains("Duplicate entry")) {
                 return Response.status(Response.Status.CONFLICT.getStatusCode()).entity(
                         ex.getCause() != null ? ex.getCause().getMessage() : null).build();
 
             }
             logger.error("Constraint Violation during creating or initiating StateMachine" +
-                    " with id {} {}", stateMachineInstanceId, ex.getStackTrace());
+                    " with id {} {} {}", stateMachineInstanceId, ex.getCause().getMessage(), ex.getStackTrace());
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode()).entity(
                     ex.getCause() != null ? ex.getCause().getMessage() : null).build();
 

--- a/runtime/src/main/java/com/flipkart/flux/resource/StateMachineResource.java
+++ b/runtime/src/main/java/com/flipkart/flux/resource/StateMachineResource.java
@@ -160,10 +160,12 @@ public class StateMachineResource {
                     append(".started").toString());
         } catch (ConstraintViolationException ex) {
             //In case of Duplicate correlation key, return http code 409 conflict
-            if (ex.getCause().getMessage().contains("Duplicate entry")) {
-                return Response.status(Response.Status.CONFLICT.getStatusCode()).entity(
-                        ex.getCause() != null ? ex.getCause().getMessage() : null).build();
+            if(ex.getCause() != null) {
+                if (ex.getCause().getMessage().contains("Duplicate entry")) {
+                    return Response.status(Response.Status.CONFLICT.getStatusCode()).entity(
+                            ex.getCause() != null ? ex.getCause().getMessage() : null).build();
 
+                }
             }
             logger.error("Constraint Violation during creating or initiating StateMachine" +
                     " with id {} {} {}", stateMachineInstanceId, ex.getCause().getMessage(), ex.getStackTrace());

--- a/runtime/src/main/java/com/flipkart/flux/resource/StateMachineResource.java
+++ b/runtime/src/main/java/com/flipkart/flux/resource/StateMachineResource.java
@@ -163,7 +163,7 @@ public class StateMachineResource {
             if(ex.getCause() != null) {
                 if (ex.getCause().getMessage().toLowerCase().contains("duplicate entry")) {
                     return Response.status(Response.Status.CONFLICT.getStatusCode()).entity(
-                            ex.getCause() != null ? ex.getCause().getMessage() : null).build();
+                            ex.getCause().getMessage()).build();
 
                 }
             }

--- a/runtime/src/main/java/com/flipkart/flux/resource/StateMachineResource.java
+++ b/runtime/src/main/java/com/flipkart/flux/resource/StateMachineResource.java
@@ -161,7 +161,7 @@ public class StateMachineResource {
         } catch (ConstraintViolationException ex) {
             //In case of Duplicate correlation key, return http code 409 conflict
             if(ex.getCause() != null) {
-                if (ex.getCause().getMessage().contains("Duplicate entry")) {
+                if (ex.getCause().getMessage().toLowerCase().contains("duplicate entry")) {
                     return Response.status(Response.Status.CONFLICT.getStatusCode()).entity(
                             ex.getCause() != null ? ex.getCause().getMessage() : null).build();
 

--- a/runtime/src/main/java/com/flipkart/flux/resource/StateMachineResource.java
+++ b/runtime/src/main/java/com/flipkart/flux/resource/StateMachineResource.java
@@ -37,11 +37,9 @@ import com.flipkart.flux.representation.StateMachinePersistenceService;
 import com.flipkart.flux.task.eventscheduler.EventSchedulerRegistry;
 import com.flipkart.flux.utils.LoggingUtils;
 import com.google.inject.Inject;
-import org.apache.commons.lang.ObjectUtils;
 import org.hibernate.exception.ConstraintViolationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.MDC;
 
 import javax.inject.Named;
 import javax.inject.Singleton;

--- a/runtime/src/test/java/com/flipkart/flux/resource/StateMachineResourceTest.java
+++ b/runtime/src/test/java/com/flipkart/flux/resource/StateMachineResourceTest.java
@@ -185,6 +185,13 @@ public class StateMachineResourceTest {
     }
 
     @Test
+    public void testCreateStateMachine_shouldReturn5xxForNonDuplicateIdConstraintViolation() throws Exception {
+        String stateMachineDefinitionJson = IOUtils.toString(this.getClass().getClassLoader().getResourceAsStream("state_machine_definition_broken.json"));
+        final HttpResponse<String> response = Unirest.post(STATE_MACHINE_RESOURCE_URL).header("Content-Type", "application/json").body(stateMachineDefinitionJson).asString();
+        assertThat(response.getStatus()).isEqualTo(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
+    }
+
+    @Test
     public void testPostEvent() throws Exception {
         //  doReturn(202).when(spyTaskDispatcher).forwardExecutionMessage(anyString(), anyObject());
         //when(spyTaskDispatcher.forwardExecutionMessage(anyString(), anyObject())).thenReturn(202);

--- a/runtime/src/test/resources/state_machine_definition_broken.json
+++ b/runtime/src/test/resources/state_machine_definition_broken.json
@@ -4,7 +4,7 @@
   "description": "desc",
   "correlationId" : "magic_number_1",
   "states": [
-      {
+    {
       "version": 1,
       "name": null,
       "description": "desc1",
@@ -17,14 +17,6 @@
       "outputEvent": {
         "name": "event1",
         "type": "java.lang.String"
-        }
-      }
-      ],
-      "retryCount": "1",
-      "timeout": "100",
-      "outputEvent": {
-        "name": "event3",
-        "type": "java.lang.Integer"
       }
     }
   ],

--- a/runtime/src/test/resources/state_machine_definition_broken.json
+++ b/runtime/src/test/resources/state_machine_definition_broken.json
@@ -1,0 +1,32 @@
+{
+  "name": "test_state_machine",
+  "version": 1,
+  "description": "desc",
+  "correlationId" : "magic_number_1",
+  "states": [
+      {
+      "version": 1,
+      "name": null,
+      "description": "desc1",
+      "onEntryHook": "com.flipkart.flux.dao.DummyOnEntryHook",
+      "task": "com.flipkart.flux.dao.TestWorkflow_testTask_java.lang.String_version1",
+      "onExitHook": "com.flipkart.flux.dao.DummyOnExitHook",
+      "dependencies": [],
+      "retryCount": "5",
+      "timeout": "100",
+      "outputEvent": {
+        "name": "event1",
+        "type": "java.lang.String"
+        }
+      }
+      ],
+      "retryCount": "1",
+      "timeout": "100",
+      "outputEvent": {
+        "name": "event3",
+        "type": "java.lang.Integer"
+      }
+    }
+  ],
+  "clientElbId" : "defaultElbId"
+}


### PR DESCRIPTION
In case of constraint violation, changed response code to 500
(INTERNAL_SERVER_ERROR) if it is not for duplicate State Machine Id.
For duplciate state machine id, it sends 409 (CONFLICT) as response.

All tests passing.