### PR TITLE
Changes to enable/disable auditing to database via config

### DIFF
--- a/persistence-mysql/src/main/java/com/flipkart/flux/persistence/dao/impl/AuditDAOV1Impl.java
+++ b/persistence-mysql/src/main/java/com/flipkart/flux/persistence/dao/impl/AuditDAOV1Impl.java
@@ -33,13 +33,20 @@ import com.google.inject.name.Named;
  */
 public class AuditDAOV1Impl extends AbstractDAO<AuditRecord> implements AuditDAOV1{
 
+	private boolean enableAuditRecord;
+
     @Inject
-    public AuditDAOV1Impl(@Named("fluxSessionFactoriesContext") SessionFactoryContext sessionFactoryContext) {
+    public AuditDAOV1Impl(@Named("fluxSessionFactoriesContext") SessionFactoryContext sessionFactoryContext, @Named("enableAuditRecord") boolean enableAuditRecord) {
         super(sessionFactoryContext);
+        this.enableAuditRecord = enableAuditRecord;
     }
 	
 	@Override
 	public AuditRecord create(AuditRecord auditRecord) {
+    	if(!enableAuditRecord) {
+    		return null;
+    	}
+    	
         if (auditRecord.getErrors() != null && auditRecord.getErrors().toCharArray().length > 999){
             // As in db we are storing the column as varchar(1000)
             auditRecord.setErrors(auditRecord.getErrors().substring(0, ERROR_MSG_LENGTH_IN_AUDIT));

--- a/persistence/src/main/java/com/flipkart/flux/persistence/dao/iface/AuditDAO.java
+++ b/persistence/src/main/java/com/flipkart/flux/persistence/dao/iface/AuditDAO.java
@@ -46,4 +46,9 @@ public interface AuditDAO {
      * Creates Audit record using the parameter session and returns the saved object
      */
     AuditRecord create_NonTransactional(AuditRecord auditRecord, Session session);
+    
+    /**
+     * Enable persisting  audit record to database.
+     */
+    void enableAuditRecord(boolean value);
 }

--- a/runtime/src/main/resources/packaged/configuration.yml
+++ b/runtime/src/main/resources/packaged/configuration.yml
@@ -109,3 +109,5 @@ connector:
 deploymentType: directory
 deploymentUnitsPath: "/tmp/workflows/"
 
+enableAuditRecord: True
+

--- a/runtime/src/main/resources/packaged/executionConfiguration.yml
+++ b/runtime/src/main/resources/packaged/executionConfiguration.yml
@@ -27,6 +27,6 @@ flux.Orchestration.URL: "http://localhost:9998"
 deploymentType: directory
 deploymentUnitsPath: "/tmp/workflows/"
 
-
+enableAuditRecord: True
 
 

--- a/runtime/src/main/resources/packaged/orchestrationConfiguration.yml
+++ b/runtime/src/main/resources/packaged/orchestrationConfiguration.yml
@@ -95,3 +95,4 @@ connector:
   connection.timeout: 10000
   socket.timeout: 10000
 
+enableAuditRecord: True

--- a/runtime/src/test/java/com/flipkart/flux/dao/AuditDAOTest.java
+++ b/runtime/src/test/java/com/flipkart/flux/dao/AuditDAOTest.java
@@ -14,6 +14,7 @@
 package com.flipkart.flux.dao;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertNull;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Before;
@@ -110,5 +111,24 @@ public class AuditDAOTest {
 
         AuditRecord auditRecord1 = auditDAO.findById(stateMachine.getId(), recordId);
         assertThat(auditRecord1.getErrors()).isEqualTo(errorMsg);
+    }
+    
+    @Test
+    public void enableAuditRecordNegativeTest() {
+      StateMachine stateMachine = dbClearWithTestSMRule.getStateMachine();
+      State state = null;
+      for (Object ob : stateMachine.getStates()) {
+        state = (State) ob;
+        break;
+      }
+      AuditRecord auditRecord = new AuditRecord(stateMachine.getId(),
+          (state != null) ? state.getId() : null,
+          0L, Status.completed, null, null, 0L,
+          null);
+      auditDAO.enableAuditRecord(false);
+
+      AuditRecord auditRecord1 = auditDAO.create(stateMachine.getId(), auditRecord);
+      assertNull(auditRecord1);
+      auditDAO.enableAuditRecord(true);
     }
 }

--- a/runtime/src/test/java/com/flipkart/flux/integration/LoadTestSimpleWorkFlow.java
+++ b/runtime/src/test/java/com/flipkart/flux/integration/LoadTestSimpleWorkFlow.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2012-2016, the original author or authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.flipkart.flux.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Set;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.flipkart.flux.FluxRuntimeRole;
+import com.flipkart.flux.InjectFromRole;
+import com.flipkart.flux.client.FluxClientComponentModule;
+import com.flipkart.flux.client.FluxClientInterceptorModule;
+import com.flipkart.flux.deploymentunit.iface.DeploymentUnitsManager;
+import com.flipkart.flux.domain.StateMachine;
+import com.flipkart.flux.guice.module.AkkaModule;
+import com.flipkart.flux.guice.module.ConfigModule;
+import com.flipkart.flux.guice.module.ContainerModule;
+import com.flipkart.flux.guice.module.ExecutionContainerModule;
+import com.flipkart.flux.guice.module.ExecutionTaskModule;
+import com.flipkart.flux.guice.module.OrchestrationTaskModule;
+import com.flipkart.flux.guice.module.OrchestratorContainerModule;
+import com.flipkart.flux.guice.module.ShardModule;
+import com.flipkart.flux.initializer.ExecutionOrderedComponentBooter;
+import com.flipkart.flux.initializer.OrchestrationOrderedComponentBooter;
+import com.flipkart.flux.module.DeploymentUnitTestModule;
+import com.flipkart.flux.module.RuntimeTestModule;
+import com.flipkart.flux.persistence.dao.iface.EventsDAO;
+import com.flipkart.flux.persistence.dao.iface.StateMachinesDAO;
+import com.flipkart.flux.persistence.dao.iface.StatesDAO;
+import com.flipkart.flux.persistence.dao.impl.ParallelScatterGatherQueryHelper;
+import com.flipkart.flux.redriver.dao.MessageDao;
+import com.flipkart.flux.registry.TaskExecutableRegistryImpl;
+import com.flipkart.flux.rule.DbClearRule;
+import com.flipkart.flux.runner.GuiceJunit4Runner;
+import com.flipkart.flux.runner.Modules;
+import com.flipkart.flux.task.redriver.RedriverRegistry;
+import com.mashape.unirest.http.Unirest;
+import com.mashape.unirest.http.exceptions.UnirestException;
+
+@RunWith(GuiceJunit4Runner.class)
+@Modules(orchestrationModules = {ConfigModule.class, FluxClientComponentModule.class, ShardModule.class,
+    RuntimeTestModule.class, ContainerModule.class,
+    OrchestrationTaskModule.class, OrchestratorContainerModule.class, FluxClientInterceptorModule.class},
+    executionModules = {ConfigModule.class, FluxClientComponentModule.class, DeploymentUnitTestModule.class,
+        AkkaModule.class, ExecutionTaskModule.class, ExecutionContainerModule.class,ContainerModule.class,
+        FluxClientInterceptorModule.class})
+public class LoadTestSimpleWorkFlow {
+
+  @Rule
+  @InjectFromRole(value = FluxRuntimeRole.ORCHESTRATION)
+  public DbClearRule dbClearRule;
+  @InjectFromRole(value = FluxRuntimeRole.ORCHESTRATION)
+  StateMachinesDAO stateMachinesDAO;
+  @InjectFromRole(value = FluxRuntimeRole.ORCHESTRATION)
+  ParallelScatterGatherQueryHelper parallelScatterGatherQueryHelper;
+  @InjectFromRole(value = FluxRuntimeRole.ORCHESTRATION)
+  EventsDAO eventsDAO;
+  @InjectFromRole(value = FluxRuntimeRole.ORCHESTRATION)
+  StatesDAO statesDAO;
+  @InjectFromRole(value = FluxRuntimeRole.ORCHESTRATION)
+  SimpleWorkflow simpleWorkflow;
+  @InjectFromRole(value = FluxRuntimeRole.ORCHESTRATION)
+  OrchestrationOrderedComponentBooter orchestrationOrderedComponentBooter;
+  @InjectFromRole(value = FluxRuntimeRole.ORCHESTRATION)
+  TestCancelPathWorkflow testCancelPathWorkflow;
+  @InjectFromRole(value = FluxRuntimeRole.ORCHESTRATION)
+  TestReplayEventTriggerWorkflow testReplayEventTriggerWorkflow;
+  /**
+   * Needed to populate deployment units before beginning the test
+   */
+  @InjectFromRole(value = FluxRuntimeRole.EXECUTION)
+  DeploymentUnitsManager deploymentUnitManager;
+  @InjectFromRole(value = FluxRuntimeRole.EXECUTION)
+  TaskExecutableRegistryImpl registry;
+  @InjectFromRole(value = FluxRuntimeRole.EXECUTION)
+  ExecutionOrderedComponentBooter executionOrderedComponentBooter;
+  @InjectFromRole(value = FluxRuntimeRole.ORCHESTRATION)
+  RedriverRegistry redriverRegistry;
+  @InjectFromRole(value = FluxRuntimeRole.ORCHESTRATION)
+  MessageDao messageDao;
+
+  @Before
+  public void setUp() {
+    try {
+      Unirest.post("http://localhost:9998/api/client-elb/create")
+          .queryString("clientId", "defaultElbId").queryString("clientElbUrl",
+          "http://localhost:9997").asString();
+    } catch (UnirestException e) {
+      e.printStackTrace();
+    }
+  }
+
+  @After
+  public void tearDown() {
+    try {
+      Unirest.post("http://localhost:9998/api/client-elb/delete")
+          .queryString("clientId", "defaultElbId").asString();
+    } catch (UnirestException e) {
+      e.printStackTrace();
+    }
+  }
+  
+  @Test
+  public void loadTestSimpleWorkflowE2E() throws Exception {    
+    int count = 1000;
+    long start = System.currentTimeMillis();
+    for(int i=0;i<count;i++) {
+        simpleWorkflow.simpleDummyWorkflow(new StringEvent("startingEvent"));
+    }
+
+    /* Asserts*/
+    final Set<StateMachine> smInDb = parallelScatterGatherQueryHelper
+        .findStateMachinesByNameAndVersion(
+            "com.flipkart.flux.integration.SimpleWorkflow_simpleDummyWorkflow_void_com.flipkart.flux.integration.StringEvent_version1",
+            1l);
+    assertThat(smInDb).hasSize(count);
+
+    /** All the events should be in triggered state after execution*/
+    while(true) {
+	    int success = 0;
+	    for(StateMachine sm : smInDb) {
+	    	List<String> resp = eventsDAO.findTriggeredOrCancelledEventsNamesBySMId(sm.getId());
+	    	if(resp.size()==3);{
+	    		//executed.
+	    		success++;
+	    	}
+	    }
+
+	    if(success == count) {
+	        long end = System.currentTimeMillis();
+	    	System.out.println("All completed in " + (end-start)/1000 + " seconds");
+	    	break;
+	    }else {
+	    	System.out.println("Yet to complete");
+	    	Thread.sleep(1000);
+	    }
+    }
+  }
+}


### PR DESCRIPTION
Details: https://confluence.fkinternal.com/pages/viewpage.action?spaceKey=SF&title=Flux+Query+Analysis

This PR will enable the capability to control audit behavior with a flag enableAuditRecord. Primarily intended to improve the overall throughput and better data management while we lose the capability to see audit info in fsmview.

Results from loadtest => About 14% overall throughput improvement in local env.

1000 WF's, Audit Enabled (Default):
Time: All completed in 28 seconds

1000 WF's, Audit Disabled:
Time: All completed in 24 seconds